### PR TITLE
atari-hd: test suite + CI workflow (epic-002)

### DIFF
--- a/.github/workflows/test-atari-hd.yml
+++ b/.github/workflows/test-atari-hd.yml
@@ -1,0 +1,44 @@
+name: atari-hd tests
+
+# Stdlib-only unittest suite for the scripts/atari-hd/atari_hd.py image
+# creator. Runs on every PR to main and every push to main, but only
+# when files under scripts/atari-hd/ actually change -- RP firmware
+# PRs don't burn minutes here.
+#
+# No third-party packages: the workflow uses the runner's stock Python
+# and runs `python -m unittest discover` directly. The image creator
+# is itself stdlib-only by design.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/atari-hd/**'
+      - '.github/workflows/test-atari-hd.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/atari-hd/**'
+      - '.github/workflows/test-atari-hd.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run atari-hd test suite
+        run: python -m unittest discover scripts/atari-hd/tests -v

--- a/scripts/atari-hd/tests/README.md
+++ b/scripts/atari-hd/tests/README.md
@@ -1,0 +1,51 @@
+# atari_hd test suite
+
+Stdlib-only `unittest` suite for `scripts/atari-hd/atari_hd.py`. Runs on
+macOS, Linux, and Windows with zero installs.
+
+## Run
+
+From the repo root:
+
+```bash
+python -m unittest discover scripts/atari-hd/tests -v
+```
+
+Exits 0 on green, non-zero on any failure.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Marks the directory as a Python package. |
+| `_support.py` | `sys.path` bootstrap + helper stubs (`parse_bpb`, `parse_ahdi_root`). |
+| `test_smoke.py` | Discovery / import sanity check. |
+| `parity.py` | Developer-only byte-parity check vs. `mkfs.vfat` (landed by epic-001 / story 003). Not part of the `unittest` suite — runs as a standalone script when `dosfstools` is installed. |
+
+Test modules import the script under test via:
+
+```python
+from _support import atari_hd
+```
+
+When `unittest discover` roots at `scripts/atari-hd/tests/`, that
+directory is on `sys.path`, so `_support` resolves directly. The
+bootstrap inside `_support.py` then adds `scripts/atari-hd/` to
+`sys.path` so `import atari_hd` finds the script regardless of the
+caller's cwd.
+
+## Rules
+
+- **Stdlib only.** No third-party imports anywhere under `tests/`.
+- **No external binaries.** No `mkfs.vfat`, no `mount`, no `hdiutil`.
+- **No fixtures in git.** Every artifact lives under
+  `tempfile.TemporaryDirectory()`.
+- **Tests stay tiny.** Total runtime budget under 30 s on a modern
+  laptop.
+
+## Design rationale
+
+Lives in `scripts/atari-hd/epics/epic-002-test-suite/` (local working
+tree only — `epics/` is gitignored). That folder holds the epic
+overview, the coverage map, and the per-story plan; this README is
+just the user-facing run instructions.

--- a/scripts/atari-hd/tests/__init__.py
+++ b/scripts/atari-hd/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Stdlib unittest suite for scripts/atari-hd/atari_hd.py."""

--- a/scripts/atari-hd/tests/_support.py
+++ b/scripts/atari-hd/tests/_support.py
@@ -1,0 +1,34 @@
+"""Shared bootstrap and helper stubs for the atari_hd test suite.
+
+Tests import the script under test via:
+
+    from _support import atari_hd
+
+The sys.path manipulation below makes that import resolve to
+scripts/atari-hd/atari_hd.py regardless of the caller's cwd.
+"""
+
+import sys
+from pathlib import Path
+
+# Make scripts/atari-hd/ importable so `import atari_hd` works from any
+# cwd. unittest discover roots at scripts/atari-hd/tests/, which puts
+# this directory on sys.path; we add the parent so the script under
+# test resolves too.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import atari_hd  # noqa: E402
+
+
+def parse_bpb(buf, offset):
+    """Parse a 512-byte FAT16 boot sector / BPB starting at `offset` in
+    `buf`. Returns a dict keyed by field name. Real implementation lands
+    in epic-002 / story 006."""
+    raise NotImplementedError("parse_bpb is not implemented yet")
+
+
+def parse_ahdi_root(buf):
+    """Parse an AHDI root sector and return the list of partition slots
+    with start LBA, size, and type. Real implementation lands in
+    epic-002 / story 003."""
+    raise NotImplementedError("parse_ahdi_root is not implemented yet")

--- a/scripts/atari-hd/tests/_support.py
+++ b/scripts/atari-hd/tests/_support.py
@@ -103,10 +103,46 @@ def parse_xgm_descriptor(buf):
 
 
 def parse_bpb(buf, offset):
-    """Parse a 512-byte FAT16 boot sector / BPB starting at `offset` in
-    `buf`. Returns a dict keyed by field name. Real implementation lands
-    in epic-002 / story 006."""
-    raise NotImplementedError("parse_bpb is not implemented yet")
+    """Parse the BPB / extended boot record at `offset` in a FAT16 boot
+    sector buffer. Returns every documented field as a plain int or bytes
+    value.
+
+    Layout follows the Microsoft / mkfs.fat convention; multi-byte fields
+    are little-endian. Pure struct.unpack_from for the integer fields.
+    """
+    base = offset
+    return {
+        "jump":                    bytes(buf[base + 0x00:base + 0x03]),
+        "oem":                     bytes(buf[base + 0x03:base + 0x0B]),
+        "bytes_per_sector":        struct.unpack_from(
+                                       "<H", buf, base + 0x0B)[0],
+        "sectors_per_cluster":     buf[base + 0x0D],
+        "reserved_sectors":        struct.unpack_from(
+                                       "<H", buf, base + 0x0E)[0],
+        "num_fats":                buf[base + 0x10],
+        "root_entries":            struct.unpack_from(
+                                       "<H", buf, base + 0x11)[0],
+        "total_sectors_16":        struct.unpack_from(
+                                       "<H", buf, base + 0x13)[0],
+        "media_descriptor":        buf[base + 0x15],
+        "sectors_per_fat_16":      struct.unpack_from(
+                                       "<H", buf, base + 0x16)[0],
+        "sectors_per_track":       struct.unpack_from(
+                                       "<H", buf, base + 0x18)[0],
+        "num_heads":               struct.unpack_from(
+                                       "<H", buf, base + 0x1A)[0],
+        "hidden_sectors":          struct.unpack_from(
+                                       "<I", buf, base + 0x1C)[0],
+        "total_sectors_32":        struct.unpack_from(
+                                       "<I", buf, base + 0x20)[0],
+        "drive_number":            buf[base + 0x24],
+        "extended_boot_signature": buf[base + 0x26],
+        "volume_id":               struct.unpack_from(
+                                       "<I", buf, base + 0x27)[0],
+        "volume_label":            bytes(buf[base + 0x2B:base + 0x36]),
+        "fs_type":                 bytes(buf[base + 0x36:base + 0x3E]),
+        "signature":               bytes(buf[base + 0x1FE:base + 0x200]),
+    }
 
 
 # 512-byte physical sector. Used by the chain walker; copied here rather

--- a/scripts/atari-hd/tests/_support.py
+++ b/scripts/atari-hd/tests/_support.py
@@ -107,3 +107,106 @@ def parse_bpb(buf, offset):
     `buf`. Returns a dict keyed by field name. Real implementation lands
     in epic-002 / story 006."""
     raise NotImplementedError("parse_bpb is not implemented yet")
+
+
+# 512-byte physical sector. Used by the chain walker; copied here rather
+# than imported from atari_hd to keep _support.py self-describing.
+_SECTOR_SIZE = 512
+
+
+def _read_sector(image_path, lba):
+    with open(image_path, "rb") as f:
+        f.seek(lba * _SECTOR_SIZE)
+        return f.read(_SECTOR_SIZE)
+
+
+def walk_image(image_path, format_id):
+    """Recover the partition list from a built image: parse the root
+    sector and chase any extended chain. Returns a list of dicts in
+    plan order (primaries first, then logicals from the chain).
+
+    For AHDI: each entry has keys start_lba, size_sectors, ident.
+    For MBR (PPDRIVER / HDDRIVER): start_lba, size_sectors, part_type.
+
+    The walker is the inverse of build_image()'s partition-table writes
+    and is the only honest end-to-end check for the writers' offsets,
+    chain pointers, and relative-LBA conventions.
+    """
+    sec0 = _read_sector(image_path, 0)
+    if format_id == atari_hd.FORMAT_AHDI:
+        return _walk_ahdi(image_path, sec0)
+    return _walk_mbr(image_path, sec0)
+
+
+def _walk_ahdi(image_path, sec0):
+    slots = parse_ahdi_root(sec0)
+    result = []
+    chain_base = None
+    chain_link = None
+    for slot in slots:
+        if slot["flag"] == 0:
+            continue
+        if slot["ident"] == b"XGM":
+            chain_base = slot["start_lba"]
+            chain_link = slot["start_lba"]
+            continue
+        result.append({
+            "start_lba":    slot["start_lba"],
+            "size_sectors": slot["size_sectors"],
+            "ident":        slot["ident"],
+        })
+    while chain_link is not None:
+        desc = parse_xgm_descriptor(_read_sector(image_path, chain_link))
+        logical = desc["logical"]
+        # Logical's start is RELATIVE to the descriptor's own LBA.
+        abs_start = chain_link + logical["start_lba"]
+        result.append({
+            "start_lba":    abs_start,
+            "size_sectors": logical["size_sectors"],
+            "ident":        logical["ident"],
+        })
+        link = desc["link"]
+        if link["flag"] == 0:
+            break
+        # Link's start is RELATIVE to the chain base.
+        chain_link = chain_base + link["start_lba"]
+    return result
+
+
+# MBR partition type for an extended (LBA) container.
+_MBR_TYPE_EXTENDED = 0x0F
+
+
+def _walk_mbr(image_path, sec0):
+    mbr = parse_mbr_root(sec0)
+    result = []
+    ext_base = None
+    ext_link = None
+    for slot in mbr["slots"]:
+        if slot["part_type"] == 0:
+            continue
+        if slot["part_type"] == _MBR_TYPE_EXTENDED:
+            ext_base = slot["rel_start_lba"]
+            ext_link = slot["rel_start_lba"]
+            continue
+        result.append({
+            "start_lba":    slot["rel_start_lba"],
+            "size_sectors": slot["sector_count"],
+            "part_type":    slot["part_type"],
+        })
+    while ext_link is not None:
+        ebr = parse_ebr(_read_sector(image_path, ext_link))
+        logical = ebr["slots"][0]
+        # Logical's start is RELATIVE to the EBR's own LBA.
+        abs_start = ext_link + logical["rel_start_lba"]
+        result.append({
+            "start_lba":    abs_start,
+            "size_sectors": logical["sector_count"],
+            "part_type":    logical["part_type"],
+        })
+        link = ebr["slots"][1]
+        if link["part_type"] == 0:
+            break
+        # Next-EBR link's start is RELATIVE to the chain base.
+        ext_link = ext_base + link["rel_start_lba"]
+    return result

--- a/scripts/atari-hd/tests/_support.py
+++ b/scripts/atari-hd/tests/_support.py
@@ -1,4 +1,4 @@
-"""Shared bootstrap and helper stubs for the atari_hd test suite.
+"""Shared bootstrap and helper parsers for the atari_hd test suite.
 
 Tests import the script under test via:
 
@@ -8,6 +8,7 @@ The sys.path manipulation below makes that import resolve to
 scripts/atari-hd/atari_hd.py regardless of the caller's cwd.
 """
 
+import struct
 import sys
 from pathlib import Path
 
@@ -20,15 +21,89 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import atari_hd  # noqa: E402
 
 
+# AHDI root-sector slot offsets (12 bytes per slot).
+AHDI_SLOT_OFFSETS = (0x1C6, 0x1D2, 0x1DE, 0x1EA)
+
+# MBR root-sector slot offsets (16 bytes per slot).
+MBR_SLOT_OFFSETS = (0x1BE, 0x1CE, 0x1DE, 0x1EE)
+
+
+def parse_ahdi_entry(buf, offset):
+    """Parse a 12-byte AHDI entry at `offset` in `buf`.
+
+    Layout (big-endian for the two 32-bit fields, per the AHDI/Atari
+    convention):
+        +0   flag        (1 byte)
+        +1   ident       (3 bytes)  e.g. b"GEM" / b"BGM" / b"XGM"
+        +4   start_lba   (4 bytes, big-endian)
+        +8   size        (4 bytes, big-endian)
+    """
+    start_lba, size_sectors = struct.unpack_from(">II", buf, offset + 4)
+    return {
+        "flag":         buf[offset],
+        "ident":        bytes(buf[offset + 1:offset + 4]),
+        "start_lba":    start_lba,
+        "size_sectors": size_sectors,
+    }
+
+
+def parse_ahdi_root(buf):
+    """Parse the four AHDI slots from a root sector. Returns a list of
+    four dicts (empty slots come back with flag=0 / ident=b'\\x00\\x00\\x00')."""
+    return [parse_ahdi_entry(buf, off) for off in AHDI_SLOT_OFFSETS]
+
+
+def parse_mbr_entry(buf, offset):
+    """Parse a 16-byte MBR partition entry at `offset` in `buf`.
+
+    Layout (little-endian for the two 32-bit fields, per IBM/Microsoft
+    MBR convention):
+        +0   boot          (1 byte; 0x80 marks active/bootable)
+        +1   chs_first     (3 bytes; encoded by pack_chs)
+        +4   part_type     (1 byte)
+        +5   chs_last      (3 bytes)
+        +8   rel_start_lba (4 bytes, little-endian; for EBRs this is
+                            relative to the EBR sector or the chain base)
+        +12  sector_count  (4 bytes, little-endian)
+    """
+    rel_start_lba, sector_count = struct.unpack_from("<II", buf, offset + 8)
+    return {
+        "boot":          buf[offset],
+        "chs_first":     bytes(buf[offset + 1:offset + 4]),
+        "part_type":     buf[offset + 4],
+        "chs_last":      bytes(buf[offset + 5:offset + 8]),
+        "rel_start_lba": rel_start_lba,
+        "sector_count":  sector_count,
+    }
+
+
+def parse_mbr_root(buf):
+    """Parse the four MBR slots + the 0x55AA signature. Returns
+    {"slots": [<4 dicts>], "signature": bytes(2)}."""
+    return {
+        "slots":     [parse_mbr_entry(buf, off) for off in MBR_SLOT_OFFSETS],
+        "signature": bytes(buf[510:512]),
+    }
+
+
+def parse_ebr(buf):
+    """An EBR has the same on-disk layout as an MBR root (4 slot positions
+    + signature); only slots 0 and 1 are populated in practice."""
+    return parse_mbr_root(buf)
+
+
+def parse_xgm_descriptor(buf):
+    """Parse an AHDI XGM sub-descriptor: slot 0 = logical partition,
+    slot 1 = next-descriptor link (or empty when chain ends). Slots 2/3
+    are unused; no MBR signature."""
+    return {
+        "logical": parse_ahdi_entry(buf, AHDI_SLOT_OFFSETS[0]),
+        "link":    parse_ahdi_entry(buf, AHDI_SLOT_OFFSETS[1]),
+    }
+
+
 def parse_bpb(buf, offset):
     """Parse a 512-byte FAT16 boot sector / BPB starting at `offset` in
     `buf`. Returns a dict keyed by field name. Real implementation lands
     in epic-002 / story 006."""
     raise NotImplementedError("parse_bpb is not implemented yet")
-
-
-def parse_ahdi_root(buf):
-    """Parse an AHDI root sector and return the list of partition slots
-    with start LBA, size, and type. Real implementation lands in
-    epic-002 / story 003."""
-    raise NotImplementedError("parse_ahdi_root is not implemented yet")

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -1,0 +1,236 @@
+"""Cap enforcement tests for atari_hd.py.
+
+Locks the partition-size and partition-count rules that guard the
+boot-from-TOS / drive-letter constraints. Each rule landed via a
+separate user correction during the original build-out; these tests
+prevent re-discovering them the hard way.
+
+Covered:
+  - partition_cap_mb: AHDI per-slot caps, hybrid no-per-slot caps.
+  - ahdi_partition_id: first slot always GEM; threshold pick for slots 1+.
+  - partition_layout: primary/extended split per format for representative N.
+  - Rejection paths: out-of-range N, AHDI strict caps, AHDI permissive caps,
+    HDDRIVER primary cap (always 1), first-AHDI-must-be-GEM invariant.
+"""
+
+import unittest
+
+from _support import atari_hd
+
+
+FORMATS = (atari_hd.FORMAT_AHDI,
+           atari_hd.FORMAT_PPDRIVER,
+           atari_hd.FORMAT_HDDRIVER)
+
+
+class TestPartitionCapMb(unittest.TestCase):
+    """partition_cap_mb returns the right per-slot ceiling for each
+    (format, strict, slot) combination."""
+
+    def test_ahdi_strict_gem_cap(self):
+        # Slot 0 is the boot/GEM partition. Strict TOS<1.04 caps GEM at 16 MB.
+        self.assertEqual(
+            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, True, 0), 16)
+
+    def test_ahdi_permissive_gem_cap(self):
+        self.assertEqual(
+            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, False, 0), 32)
+
+    def test_ahdi_strict_bgm_cap(self):
+        # Slot 1+ is BGM. Strict caps BGM at 256 MB.
+        self.assertEqual(
+            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, True, 1), 256)
+
+    def test_ahdi_permissive_bgm_cap(self):
+        self.assertEqual(
+            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, False, 1), 512)
+
+    def test_ahdi_strict_bgm_cap_holds_for_higher_slots(self):
+        # Slots 2..N share the BGM cap with slot 1.
+        for slot in (1, 2, 3, 5, 13):
+            with self.subTest(slot=slot):
+                self.assertEqual(
+                    atari_hd.partition_cap_mb(
+                        atari_hd.FORMAT_AHDI, True, slot), 256)
+
+    def test_hybrid_caps_have_no_per_slot_distinction(self):
+        # PPDRIVER / HDDRIVER go through the DOS view, which doesn't care
+        # about TOS BGM limits. Cap is the FAT16 ceiling regardless of
+        # slot or strict flag.
+        for fmt in (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER):
+            for slot in (0, 1, 5, 13):
+                for strict in (True, False):
+                    with self.subTest(format=fmt, slot=slot, strict=strict):
+                        self.assertEqual(
+                            atari_hd.partition_cap_mb(fmt, strict, slot),
+                            atari_hd.MAX_PARTITION_MB)
+
+
+class TestAhdiPartitionId(unittest.TestCase):
+    """ahdi_partition_id picks the ident bytes (b'GEM' / b'BGM')."""
+
+    def test_first_partition_is_always_gem(self):
+        # Hard rule: TOS only boots from a GEM entry, so slot 0 must be
+        # GEM regardless of size or strict mode.
+        for size in (1, 16, 17, 32, 33, 100, 256, 257, 512, 1024):
+            for strict in (True, False):
+                with self.subTest(size=size, strict=strict):
+                    self.assertEqual(
+                        atari_hd.ahdi_partition_id(size, strict,
+                                                    is_first=True),
+                        b"GEM",
+                        f"size={size}, strict={strict} must be GEM")
+
+    def test_permissive_threshold_at_32mb(self):
+        # TOS 1.04+ uses a 32 MB threshold for non-first slots.
+        self.assertEqual(
+            atari_hd.ahdi_partition_id(32, False, is_first=False), b"GEM")
+        self.assertEqual(
+            atari_hd.ahdi_partition_id(33, False, is_first=False), b"BGM")
+
+    def test_strict_threshold_at_16mb(self):
+        # TOS < 1.04 tightens the threshold to 16 MB.
+        self.assertEqual(
+            atari_hd.ahdi_partition_id(16, True, is_first=False), b"GEM")
+        self.assertEqual(
+            atari_hd.ahdi_partition_id(17, True, is_first=False), b"BGM")
+
+
+class TestPartitionLayout(unittest.TestCase):
+    """partition_layout splits N partitions into primary slots vs. an
+    extended chain, per each format's convention."""
+
+    # (primary_count, has_extended, logical_count) per format per N.
+    EXPECTED = {
+        atari_hd.FORMAT_AHDI: {
+            1:  (1, False, 0),
+            2:  (2, False, 0),
+            3:  (3, False, 0),
+            4:  (4, False, 0),
+            5:  (3, True, 2),     # slot 3 becomes XGM link, 2 logicals
+            10: (3, True, 7),
+            14: (3, True, 11),
+        },
+        atari_hd.FORMAT_PPDRIVER: {
+            1:  (1, False, 0),
+            2:  (2, False, 0),
+            3:  (3, False, 0),
+            4:  (4, False, 0),
+            5:  (3, True, 2),     # MBR P3 becomes ext container
+            10: (3, True, 7),
+            14: (3, True, 11),
+        },
+        atari_hd.FORMAT_HDDRIVER: {
+            1:  (1, False, 0),     # primary cap = 1
+            2:  (1, True, 1),
+            3:  (1, True, 2),
+            4:  (1, True, 3),
+            5:  (1, True, 4),
+            10: (1, True, 9),
+            14: (1, True, 13),
+        },
+    }
+
+    def test_layout_table(self):
+        for fmt, table in self.EXPECTED.items():
+            for n, expected in table.items():
+                with self.subTest(format=fmt, n=n):
+                    layout = atari_hd.partition_layout(fmt, n)
+                    actual = (layout["primary_count"],
+                              layout["has_extended"],
+                              layout["logical_count"])
+                    self.assertEqual(
+                        actual, expected,
+                        f"\n  fmt    : {fmt}\n"
+                        f"  n      : {n}\n"
+                        f"  expect : (primary={expected[0]}, "
+                        f"ext={expected[1]}, logical={expected[2]})\n"
+                        f"  actual : (primary={actual[0]}, "
+                        f"ext={actual[1]}, logical={actual[2]})")
+
+    def test_hddriver_primary_count_never_exceeds_one(self):
+        # The "HDDRIVER > 1 primary" rule is enforced by *capping* primary
+        # at 1, not by raising; the test confirms that cap is honored.
+        for n in range(1, atari_hd.MAX_PARTITIONS[atari_hd.FORMAT_HDDRIVER] + 1):
+            with self.subTest(n=n):
+                layout = atari_hd.partition_layout(
+                    atari_hd.FORMAT_HDDRIVER, n)
+                self.assertEqual(
+                    layout["primary_count"], 1,
+                    f"HDDRIVER must cap primary at 1; got "
+                    f"{layout['primary_count']} for N={n}")
+
+
+class TestRejectionPaths(unittest.TestCase):
+    """Out-of-range inputs and cap-violating plans must raise with a
+    message that names the rule, so the failure points the user at the
+    fix instead of producing a corrupt image silently."""
+
+    def test_zero_partitions_rejected(self):
+        for fmt in FORMATS:
+            with self.subTest(format=fmt):
+                with self.assertRaises(ValueError) as ctx:
+                    atari_hd.partition_layout(fmt, 0)
+                self.assertIn("at least one partition",
+                              str(ctx.exception).lower())
+
+    def test_above_max_partitions_rejected(self):
+        for fmt in FORMATS:
+            with self.subTest(format=fmt):
+                with self.assertRaises(ValueError) as ctx:
+                    atari_hd.partition_layout(fmt, 15)
+                msg = str(ctx.exception).lower()
+                self.assertIn("supports at most", msg,
+                              f"{fmt}: {ctx.exception}")
+                self.assertIn("14", msg, f"{fmt}: {ctx.exception}")
+
+    def test_ahdi_strict_first_partition_over_gem_cap(self):
+        # 17 MB > 16 MB strict GEM cap => plan_image must reject and the
+        # message must name the rule.
+        partitions = [atari_hd.Partition(name="BOOT", size_mb=17)]
+        with self.assertRaises(ValueError) as ctx:
+            atari_hd.plan_image(atari_hd.FORMAT_AHDI, "<test>", image_mb=64,
+                                partitions=partitions, strict_tos=True)
+        msg = str(ctx.exception)
+        self.assertIn("TOS < 1.04", msg, msg)
+        self.assertIn("boot (GEM)", msg, msg)
+
+    def test_ahdi_strict_bgm_partition_over_cap(self):
+        # Slot 0 within cap, slot 1 over the strict 256 MB BGM cap.
+        partitions = [
+            atari_hd.Partition(name="BOOT", size_mb=16),
+            atari_hd.Partition(name="BIG",  size_mb=300),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            atari_hd.plan_image(atari_hd.FORMAT_AHDI, "<test>", image_mb=512,
+                                partitions=partitions, strict_tos=True)
+        msg = str(ctx.exception)
+        self.assertIn("TOS < 1.04", msg, msg)
+        self.assertIn("BGM", msg, msg)
+
+    def test_ahdi_permissive_first_partition_over_gem_cap(self):
+        # 33 MB > 32 MB permissive GEM cap => reject under TOS 1.04+ mode.
+        partitions = [atari_hd.Partition(name="BOOT", size_mb=33)]
+        with self.assertRaises(ValueError) as ctx:
+            atari_hd.plan_image(atari_hd.FORMAT_AHDI, "<test>", image_mb=64,
+                                partitions=partitions, strict_tos=False)
+        msg = str(ctx.exception)
+        self.assertIn("TOS 1.04+", msg, msg)
+        self.assertIn("boot (GEM)", msg, msg)
+
+    def test_ahdi_permissive_bgm_partition_over_cap(self):
+        # 600 MB > 512 MB permissive BGM cap.
+        partitions = [
+            atari_hd.Partition(name="BOOT", size_mb=32),
+            atari_hd.Partition(name="HUGE", size_mb=600),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            atari_hd.plan_image(atari_hd.FORMAT_AHDI, "<test>", image_mb=1024,
+                                partitions=partitions, strict_tos=False)
+        msg = str(ctx.exception)
+        self.assertIn("TOS 1.04+", msg, msg)
+        self.assertIn("BGM", msg, msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/atari-hd/tests/test_dual_bpb.py
+++ b/scripts/atari-hd/tests/test_dual_bpb.py
@@ -1,0 +1,149 @@
+"""Dual-BPB invariant tests for PPDRIVER / HDDRIVER hybrid images.
+
+Both hybrid layouts carry two BPBs at the start of every partition:
+  - DOS view: bytes_per_sector=512, so macOS msdosfs / Linux vfat /
+    Windows can mount the volume.
+  - TOS view: bytes_per_sector = ratio * 512 (>=1024), with a one-LBA
+    offset so its FAT/root/data physical bytes coincide with DOS's.
+
+Six invariants must hold or one of the two views breaks. This story
+asserts every invariant for every supported (format, ratio) combination.
+
+ratio=1 is intentionally absent: synthesize_tos_bpb_from_dos512 hard-
+rejects tos_bps < 1024 because the TOS view would degenerate to the
+DOS view and the dual-BPB trick would be meaningless.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from _support import atari_hd, parse_bpb
+
+
+# (ratio, partition_size_mb) pairs chosen to land cleanly in each ratio
+# bucket per choose_logical_sector_size() and to require no
+# align_partition_for_hybrid() trim (predict_mkfs_spfat % ratio == 0).
+RATIO_FIXTURES = [
+    (2,   32),
+    (4,   96),
+    (8,   128),
+    (16,  384),
+]
+
+HYBRID_FORMATS = (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER)
+
+
+def _check_invariant(test, num, condition, dos, tos, ratio, fmt):
+    """Assert one of the six invariants. Failure message names the
+    invariant number, the format, the ratio, and the relevant DOS/TOS
+    field values per spec criterion 2."""
+    test.assertTrue(condition,
+                    f"\n  invariant #{num} broken (format={fmt}, "
+                    f"ratio={ratio})\n"
+                    f"  DOS bps={dos['bytes_per_sector']} "
+                    f"spc={dos['sectors_per_cluster']} "
+                    f"res={dos['reserved_sectors']} "
+                    f"spfat={dos['sectors_per_fat_16']}\n"
+                    f"  TOS bps={tos['bytes_per_sector']} "
+                    f"spc={tos['sectors_per_cluster']} "
+                    f"res={tos['reserved_sectors']} "
+                    f"spfat={tos['sectors_per_fat_16']}")
+
+
+@unittest.skipUnless(hasattr(atari_hd, "format_fat16"),
+                     "atari_hd.format_fat16 not present "
+                     "(epic-001 / story 001 must land first)")
+class TestDualBpbInvariants(unittest.TestCase):
+    def test_invariants_across_format_and_ratio(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for fmt in HYBRID_FORMATS:
+                for ratio, size_mb in RATIO_FIXTURES:
+                    with self.subTest(format=fmt, ratio=ratio,
+                                      size_mb=size_mb):
+                        self._check_one(tmp, fmt, ratio, size_mb)
+
+    def _check_one(self, tmp, fmt, ratio, size_mb):
+        partitions = [atari_hd.Partition(name="P", size_mb=size_mb)]
+        plan = atari_hd.plan_image(
+            fmt, image_path="<placeholder>",
+            image_mb=size_mb + 4,  # leave a small tail for partition table
+            partitions=partitions, strict_tos=False)
+
+        # Verify the geometry chose the ratio we expected. If not, the
+        # rest of the test is meaningless.
+        actual_ratio = plan.partitions[0].tos_bps // 512
+        self.assertEqual(
+            actual_ratio, ratio,
+            f"format={fmt} size={size_mb} MB: planner chose "
+            f"ratio={actual_ratio}, fixture expected {ratio}")
+
+        path = Path(tmp) / f"{fmt}_r{ratio}.img"
+        plan.image_path = str(path)
+        atari_hd.build_image(plan)
+
+        # Read DOS BPB at start_lba and TOS BPB at start_lba + 1.
+        # Both BPBs are 512-byte structures regardless of the declared
+        # bytes_per_sector; parse_bpb is sector-size-agnostic.
+        first_lba = plan.partitions[0].start_lba
+        with open(path, "rb") as f:
+            f.seek(first_lba * 512)
+            dos_buf = f.read(512)
+            tos_buf = f.read(512)
+
+        dos = parse_bpb(dos_buf, 0)
+        tos = parse_bpb(tos_buf, 0)
+
+        # Sanity: the BPBs we just read must declare the bps we expect.
+        # If they don't, every other assertion is checking the wrong
+        # bytes; surface that loudly before running the invariants.
+        self.assertEqual(dos["bytes_per_sector"], 512,
+                         f"DOS BPB at LBA {first_lba} declares "
+                         f"bps={dos['bytes_per_sector']}, expected 512")
+        self.assertEqual(tos["bytes_per_sector"], ratio * 512,
+                         f"TOS BPB at LBA {first_lba + 1} declares "
+                         f"bps={tos['bytes_per_sector']}, expected "
+                         f"{ratio * 512}")
+
+        # Six invariants ---------------------------------------------
+        # #1: cluster_size_bytes match (DOS bps * spc == TOS bps * spc).
+        dos_cluster_bytes = (dos["bytes_per_sector"]
+                             * dos["sectors_per_cluster"])
+        tos_cluster_bytes = (tos["bytes_per_sector"]
+                             * tos["sectors_per_cluster"])
+        _check_invariant(self, 1,
+                         dos_cluster_bytes == tos_cluster_bytes,
+                         dos, tos, ratio, fmt)
+
+        # #2: FAT_bytes match (DOS spfat * 512 == TOS spfat * (ratio*512)).
+        dos_fat_bytes = (dos["sectors_per_fat_16"]
+                         * dos["bytes_per_sector"])
+        tos_fat_bytes = (tos["sectors_per_fat_16"]
+                         * tos["bytes_per_sector"])
+        _check_invariant(self, 2,
+                         dos_fat_bytes == tos_fat_bytes,
+                         dos, tos, ratio, fmt)
+
+        # #3: DOS_reserved_sectors == ratio + 1.
+        _check_invariant(self, 3,
+                         dos["reserved_sectors"] == ratio + 1,
+                         dos, tos, ratio, fmt)
+
+        # #4: TOS_reserved_sectors == 1.
+        _check_invariant(self, 4,
+                         tos["reserved_sectors"] == 1,
+                         dos, tos, ratio, fmt)
+
+        # #5: DOS_sectors_per_cluster == 2 * ratio.
+        _check_invariant(self, 5,
+                         dos["sectors_per_cluster"] == 2 * ratio,
+                         dos, tos, ratio, fmt)
+
+        # #6: TOS_sectors_per_cluster == 2.
+        _check_invariant(self, 6,
+                         tos["sectors_per_cluster"] == 2,
+                         dos, tos, ratio, fmt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/atari-hd/tests/test_fat16_writer.py
+++ b/scripts/atari-hd/tests/test_fat16_writer.py
@@ -1,0 +1,192 @@
+"""Structural lock-down for atari_hd.format_fat16().
+
+format_fat16() is the keystone the dual-BPB hybrid layout relies on: a
+drifted BPB field would break mount silently. This story locks the
+writer's on-disk layout behind structural assertions across a fixture
+matrix that covers single-BPB and dual-BPB DOS-view shapes plus the
+sector_size > 512 native path.
+
+This is NOT a byte-parity check vs. mkfs.vfat -- that's epic-001 /
+story 003 (Linux-only). Here we assert structural correctness only,
+so the suite stays portable across macOS / Linux / Windows.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from _support import atari_hd, parse_bpb
+
+
+# (id, partition_sectors_512, sector_size, sectors_per_cluster,
+#  reserved_sectors, label).
+#
+# Coverage:
+#  - 8 MB single-BPB at AHDI native (bps=512 spc=2).
+#  - 128 MB / 256 MB dual-BPB DOS view (bps=512, spc=2*ratio,
+#    res=ratio+1) at ratios 4 and 8.
+#  - 1 GB single-BPB at the FAT16 upper end (spc=32).
+#  - Native bps=1024 / bps=4096 to exercise sector_size > 512.
+FIXTURES = [
+    ("ahdi_8M_native",         16384,    512,  2,  2, "ATARI"),
+    ("ppdriver_dos_128M_r4",   262144,   512,  8,  5, "DOS"),
+    ("ppdriver_dos_256M_r8",   524288,   512, 16,  9, "DOS"),
+    ("single_bpb_1G",          2097152,  512, 32,  2, "LARGE"),
+    ("native_1k_16M",          32768,    1024, 2,  1, "TOS1K"),
+    ("native_4k_128M",         262144,   4096, 2,  1, "TOS4K"),
+]
+
+
+@unittest.skipUnless(hasattr(atari_hd, "format_fat16"),
+                     "atari_hd.format_fat16 not present "
+                     "(epic-001 / story 001 must land first)")
+class TestFat16Writer(unittest.TestCase):
+    def test_fixture_matrix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for fid, p_sec, ssize, spc, res, label in FIXTURES:
+                with self.subTest(id=fid, sector_size=ssize, spc=spc,
+                                  res=res):
+                    self._check_fixture(tmp, fid, p_sec, ssize, spc, res,
+                                        label)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _check_fixture(self, tmp, fid, p_sec, ssize, spc, res, label):
+        path = Path(tmp) / f"{fid}.img"
+        atari_hd.format_fat16(
+            out_path=str(path),
+            partition_sectors_512=p_sec,
+            sector_size=ssize,
+            sectors_per_cluster=spc,
+            reserved_sectors=res,
+            label=label,
+            disable_fat_align=True,
+        )
+
+        # File size is exact: partition_sectors_512 * 512.
+        self.assertEqual(os.path.getsize(path), p_sec * 512,
+                         f"{fid}: file size != partition_sectors_512 * 512")
+
+        with open(path, "rb") as f:
+            head = f.read(ssize)  # full first logical sector
+        bpb = parse_bpb(head, 0)
+
+        # Derived expectations.
+        ratio = ssize // 512
+        total_logical = p_sec // ratio
+        spfat_expected = atari_hd._fat16_compute_spfat(
+            p_sec, ssize, spc, res)
+        label_bytes = atari_hd._fat16_normalize_label(label)
+        vol_id_expected = atari_hd._fat16_seed_volume_id(
+            label_bytes, p_sec, ssize, spc, res)
+
+        # BPB field assertions ---------------------------------------
+        self.assertEqual(bpb["jump"], b"\xEB\x3C\x90", f"{fid}: jump")
+        self.assertEqual(bpb["oem"], b"MSWIN4.1", f"{fid}: OEM")
+        self.assertEqual(bpb["bytes_per_sector"], ssize,
+                         f"{fid}: bytes_per_sector")
+        self.assertEqual(bpb["sectors_per_cluster"], spc,
+                         f"{fid}: sectors_per_cluster")
+        self.assertEqual(bpb["reserved_sectors"], res,
+                         f"{fid}: reserved_sectors")
+        self.assertEqual(bpb["num_fats"], 2, f"{fid}: num_fats")
+        self.assertEqual(bpb["root_entries"], 512, f"{fid}: root_entries")
+        if total_logical < 0x10000:
+            self.assertEqual(bpb["total_sectors_16"], total_logical,
+                             f"{fid}: total_sectors_16")
+            self.assertEqual(bpb["total_sectors_32"], 0,
+                             f"{fid}: total_sectors_32 should be 0")
+        else:
+            self.assertEqual(bpb["total_sectors_16"], 0,
+                             f"{fid}: total_sectors_16 should be 0")
+            self.assertEqual(bpb["total_sectors_32"], total_logical,
+                             f"{fid}: total_sectors_32")
+        self.assertEqual(bpb["media_descriptor"], 0xF8,
+                         f"{fid}: media_descriptor")
+        self.assertEqual(bpb["sectors_per_fat_16"], spfat_expected,
+                         f"{fid}: sectors_per_fat_16 (expect "
+                         f"_fat16_compute_spfat)")
+        self.assertEqual(bpb["sectors_per_track"], 32, f"{fid}: spt")
+        self.assertEqual(bpb["num_heads"], 64, f"{fid}: num_heads")
+        self.assertEqual(bpb["hidden_sectors"], 0, f"{fid}: hidden_sectors")
+        self.assertEqual(bpb["drive_number"], 0x80, f"{fid}: drive_number")
+        self.assertEqual(bpb["extended_boot_signature"], 0x29,
+                         f"{fid}: extended_boot_signature")
+        self.assertEqual(bpb["volume_id"], vol_id_expected,
+                         f"{fid}: volume_id (expect deterministic seed)")
+        self.assertEqual(bpb["volume_label"], label_bytes.ljust(11, b" "),
+                         f"{fid}: volume_label")
+        self.assertEqual(bpb["fs_type"], b"FAT16   ", f"{fid}: fs_type")
+        self.assertEqual(bpb["signature"], b"\x55\xAA",
+                         f"{fid}: 0x55AA boot signature")
+
+        # FAT contents -----------------------------------------------
+        # Both FAT copies are byte-identical; FAT[0..3] = F8 FF FF FF
+        # and the rest of each FAT is zero (no clusters allocated).
+        fat_size_bytes = spfat_expected * ssize
+        with open(path, "rb") as f:
+            f.seek(res * ssize)
+            fat1 = f.read(fat_size_bytes)
+            fat2 = f.read(fat_size_bytes)
+        self.assertEqual(len(fat1), fat_size_bytes,
+                         f"{fid}: FAT1 short read")
+        self.assertEqual(fat1[0:4], b"\xF8\xFF\xFF\xFF",
+                         f"{fid}: FAT[0..3] head")
+        self.assertEqual(fat1[4:], b"\x00" * (fat_size_bytes - 4),
+                         f"{fid}: FAT1 tail must be all-zero "
+                         "(no clusters allocated yet)")
+        self.assertEqual(fat1, fat2,
+                         f"{fid}: FAT1 != FAT2 (must be byte-identical)")
+
+        # Root directory ---------------------------------------------
+        # Exactly one entry: the volume label. Attribute 0x08, all other
+        # fields zero. Remaining root-dir entries are all zero.
+        root_dir_bytes = 512 * 32
+        root_dir_offset_bytes = (res + 2 * spfat_expected) * ssize
+        with open(path, "rb") as f:
+            f.seek(root_dir_offset_bytes)
+            root = f.read(root_dir_bytes)
+        self.assertEqual(len(root), root_dir_bytes,
+                         f"{fid}: root dir short read")
+        # First 32 bytes: label entry.
+        self.assertEqual(root[0:11], label_bytes.ljust(11, b" "),
+                         f"{fid}: root entry name field")
+        self.assertEqual(root[11], 0x08,
+                         f"{fid}: root entry attribute byte (must be 0x08)")
+        self.assertEqual(root[12:32], b"\x00" * 20,
+                         f"{fid}: root entry tail must be zero "
+                         "(timestamps + cluster + size)")
+        # Remaining entries all-zero.
+        self.assertEqual(root[32:], b"\x00" * (root_dir_bytes - 32),
+                         f"{fid}: subsequent root entries must be empty")
+
+        # Data area sample-check -------------------------------------
+        # Read 4 KiB at start, mid, and end of the data area; assert
+        # all-zero. Sampling avoids reading the full image for large
+        # fixtures.
+        root_dir_sectors = (root_dir_bytes + ssize - 1) // ssize
+        data_start_byte = (
+            res + 2 * spfat_expected + root_dir_sectors) * ssize
+        data_end_byte = total_logical * ssize
+        self.assertGreater(data_end_byte, data_start_byte,
+                           f"{fid}: no data area present")
+        sample_size = 4096
+        positions = [
+            data_start_byte,
+            (data_start_byte + data_end_byte) // 2,
+            data_end_byte - sample_size,
+        ]
+        zero_block = b"\x00" * sample_size
+        with open(path, "rb") as f:
+            for pos in positions:
+                f.seek(pos)
+                self.assertEqual(f.read(sample_size), zero_block,
+                                 f"{fid}: data area at byte 0x{pos:X} "
+                                 "must be zero")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/atari-hd/tests/test_geometry.py
+++ b/scripts/atari-hd/tests/test_geometry.py
@@ -1,0 +1,98 @@
+"""Lock-down test for atari_hd.predict_mkfs_spfat().
+
+predict_mkfs_spfat() is the single source of truth for sectors-per-FAT
+in the dual-BPB hybrid layout. If the formula ever drifts the hybrid
+breaks silently. This test pins it behind a fixture table of known-good
+(input -> output) rows.
+
+The expected values were generated against the live function and
+spot-checked against mkfs.vfat (dosfstools 4.2) by
+scripts/atari-hd/tests/parity.py for the rows that overlap with
+parity-test fixtures. Rows marked source="formula" have not yet been
+cross-checked against mkfs.vfat directly; that's a soft TODO when
+convenient.
+"""
+
+import unittest
+
+from _support import atari_hd
+
+
+# id, partition_sectors_512, ratio, expected_spfat, source, notes
+FIXTURES = [
+    # Below the smallest valid FAT16: data area would be <= 0 even at
+    # spfat=1 -- the function must return None, not iterate forever.
+    ("too_small_r1",       36,        1, None,  "formula",
+     "below the spfat=1 floor at ratio=1"),
+    ("too_small_r4",       39,        4, None,  "formula",
+     "below the spfat=1 floor at ratio=4"),
+
+    # Smallest practical FAT16 at ratio=1: cluster_count == 4085 exactly,
+    # right at the FAT12/FAT16 boundary.
+    ("min_fat16_r1",       8236,      1, 16,    "formula",
+     "smallest valid FAT16, clusters=4085 exactly"),
+
+    # 16 / 32 MB at ratio=1
+    ("16M_r1",             32768,     1, 64,    "formula", ""),
+    ("32M_r1",             65536,     1, 128,   "formula", ""),
+
+    # Largest valid FAT16 at ratio=1: clusters=65523, just below the
+    # FAT32 boundary at 65524.
+    ("max_fat16_r1",       131592,    1, 256,   "formula",
+     "largest valid FAT16, clusters=65523"),
+
+    # ratio=2 sweep
+    ("32M_r2",             65536,     2, 64,    "formula", ""),
+    ("64M_r2",             131072,    2, 128,   "formula", ""),
+    ("128M_r2",            262144,    2, 256,   "formula", ""),
+
+    # ratio=4 sweep -- 128M_r4 lines up with parity.py's
+    # dos_view_128M_ratio4 fixture which is byte-checked against mkfs.vfat.
+    ("64M_r4",             131072,    4, 64,    "formula", ""),
+    ("128M_r4",            262144,    4, 128,   "mkfs_vfat_4.2",
+     "matches parity.py dos_view_128M_ratio4"),
+    ("256M_r4",            524288,    4, 256,   "formula", ""),
+
+    # ratio=8 sweep
+    ("128M_r8",            262144,    8, 64,    "formula", ""),
+    ("256M_r8",            524288,    8, 128,   "formula", ""),
+    ("512M_r8",            1048576,   8, 256,   "formula", ""),
+
+    # The historical spfat=127 quirk: at ~128 MB with ratio=4 the
+    # iteration converges on an odd spfat (not divisible by ratio),
+    # which is what tripped the dual-BPB layer in the original PPERA
+    # work and prompted align_partition_for_hybrid().
+    ("spfat_127_quirk",    259072,    4, 127,   "formula",
+     "spfat not divisible by ratio -- triggers align_partition_for_hybrid()"),
+]
+
+
+class TestPredictMkfsSpfat(unittest.TestCase):
+    def test_fixture_table(self):
+        for row_id, sectors, ratio, expected, source, notes in FIXTURES:
+            with self.subTest(id=row_id, sectors=sectors, ratio=ratio,
+                              source=source):
+                actual = atari_hd.predict_mkfs_spfat(sectors, ratio)
+                self.assertEqual(
+                    actual, expected,
+                    msg=(f"\n  fixture: {row_id}\n"
+                         f"  inputs : sectors={sectors}, ratio={ratio}\n"
+                         f"  expect : {expected}\n"
+                         f"  actual : {actual}\n"
+                         f"  source : {source}"
+                         + (f"\n  notes  : {notes}" if notes else "")))
+
+    def test_fixture_table_has_required_coverage(self):
+        # Spec calls for at least 10 rows. Sanity-check that nobody
+        # silently shrinks the table below that floor.
+        self.assertGreaterEqual(len(FIXTURES), 10,
+                                f"only {len(FIXTURES)} fixtures defined; "
+                                "spec requires >= 10")
+        ratios = {row[2] for row in FIXTURES}
+        self.assertTrue({1, 2, 4, 8}.issubset(ratios),
+                        f"ratios covered: {ratios}; spec requires "
+                        "1, 2, 4, and 8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/atari-hd/tests/test_partition_tables.py
+++ b/scripts/atari-hd/tests/test_partition_tables.py
@@ -1,0 +1,395 @@
+"""Partition-table writer tests for atari_hd.py.
+
+Builds minimal in-memory ImagePlan objects and exercises:
+  - build_root_sector_ahdi (1..4 primaries; 5+ via XGM chain)
+  - build_root_sector_ppdriver (MBR primaries + extended container)
+  - build_root_sector_hddriver (1 primary + AHDI overlap marker; +ext)
+  - build_xgm_descriptor_sector (XGM sub-descriptors)
+  - build_ebr_sector (MBR extended-chain EBRs)
+
+Tests construct sectors in memory only -- no temp files. CHS bytes are
+deliberately not asserted (they're a derivative of start_lba via
+lba_to_chs and would couple this test to that helper); we lock LBA,
+size, type, ident, flags, and the 0x55AA signature.
+"""
+
+import unittest
+
+from _support import (
+    atari_hd,
+    AHDI_SLOT_OFFSETS,
+    MBR_SLOT_OFFSETS,
+    parse_ahdi_root,
+    parse_ahdi_entry,
+    parse_mbr_root,
+    parse_ebr,
+    parse_xgm_descriptor,
+)
+
+
+# AHDI flag combinations
+AHDI_EXISTS = 0x01
+AHDI_BOOT = 0x80
+AHDI_EXISTS_BOOT = 0x81
+
+# MBR partition types
+MBR_TYPE_FAT16 = 0x06
+MBR_TYPE_EXTENDED = 0x0F
+
+
+def _make_partition(name, size_mb, size_sectors, start_lba,
+                    ebr_lba=0, dos_bps=512, dos_spc=2, dos_res=1,
+                    tos_bps=0):
+    """Produce a fully-populated Partition. The writers only consume the
+    derived fields, so we set them all explicitly rather than running
+    plan_image()."""
+    return atari_hd.Partition(
+        name=name, size_mb=size_mb,
+        size_sectors=size_sectors, start_lba=start_lba, ebr_lba=ebr_lba,
+        dos_bps=dos_bps, dos_spc=dos_spc, dos_res=dos_res, tos_bps=tos_bps,
+    )
+
+
+def _make_plan(format_id, partitions, primary_count, has_extended=False,
+               strict_tos=False):
+    plan = atari_hd.ImagePlan(
+        format_id=format_id, image_path="<test>", image_mb=0,
+        partitions=partitions, strict_tos=strict_tos,
+    )
+    plan.primary_count = primary_count
+    plan.has_extended = has_extended
+    return plan
+
+
+def _slot_msg(label, slot_index, raw):
+    return (f"\n  {label} slot {slot_index} raw={raw.hex()}")
+
+
+class TestAhdiRoot(unittest.TestCase):
+    def test_primary_count_sweep_1_through_4(self):
+        # Per spec: cover N in {1, 2, 3, 4}. Same-size 16 MB GEM partitions
+        # so the only thing that changes is which slots are populated.
+        for n in (1, 2, 3, 4):
+            with self.subTest(primary_count=n):
+                size_sectors = 32768  # 16 MB
+                partitions = [
+                    _make_partition(f"P{i + 1}", size_mb=16,
+                                    size_sectors=size_sectors,
+                                    start_lba=2 + i * size_sectors)
+                    for i in range(n)
+                ]
+                plan = _make_plan(atari_hd.FORMAT_AHDI, partitions,
+                                  primary_count=n)
+                sec = atari_hd.build_root_sector_ahdi(plan)
+                slots = parse_ahdi_root(sec)
+
+                for i, part in enumerate(partitions):
+                    raw = sec[AHDI_SLOT_OFFSETS[i]:AHDI_SLOT_OFFSETS[i] + 12]
+                    expected_flag = AHDI_EXISTS_BOOT if i == 0 else AHDI_EXISTS
+                    self.assertEqual(slots[i]["flag"], expected_flag,
+                                     f"N={n} slot {i} flag"
+                                     f"{_slot_msg('AHDI', i, raw)}")
+                    self.assertEqual(slots[i]["ident"], b"GEM",
+                                     f"N={n} slot {i} ident"
+                                     f"{_slot_msg('AHDI', i, raw)}")
+                    self.assertEqual(slots[i]["start_lba"], part.start_lba,
+                                     f"N={n} slot {i} start_lba"
+                                     f"{_slot_msg('AHDI', i, raw)}")
+                    self.assertEqual(slots[i]["size_sectors"],
+                                     part.size_sectors,
+                                     f"N={n} slot {i} size_sectors"
+                                     f"{_slot_msg('AHDI', i, raw)}")
+                # Slots beyond `n` must be empty.
+                for i in range(n, 4):
+                    self.assertEqual(slots[i]["flag"], 0,
+                                     f"N={n} slot {i} should be empty")
+                    self.assertEqual(slots[i]["ident"], b"\x00\x00\x00")
+                    self.assertEqual(slots[i]["start_lba"], 0)
+                    self.assertEqual(slots[i]["size_sectors"], 0)
+
+                # Pure AHDI: no MBR signature regardless of N.
+                self.assertEqual(sec[510:512], b"\x00\x00",
+                                 f"N={n}: AHDI root must not carry "
+                                 "the 0x55AA MBR signature")
+
+    def test_four_primaries_mixed_gem_bgm(self):
+        # Slot 0 is forced to GEM regardless of size; slots 1+ pick GEM/BGM
+        # from the size threshold (32 MB by default).
+        partitions = [
+            _make_partition("BOOT", size_mb=16, size_sectors=32768,  start_lba=2),
+            _make_partition("S1",   size_mb=32, size_sectors=65536,  start_lba=32770),
+            _make_partition("S2",   size_mb=64, size_sectors=131072, start_lba=98306),
+            _make_partition("S3",   size_mb=128, size_sectors=262144, start_lba=229378),
+        ]
+        plan = _make_plan(atari_hd.FORMAT_AHDI, partitions, primary_count=4)
+        sec = atari_hd.build_root_sector_ahdi(plan)
+        slots = parse_ahdi_root(sec)
+
+        expected_idents = [b"GEM", b"GEM", b"BGM", b"BGM"]
+        for i, (part, want_ident) in enumerate(zip(partitions, expected_idents)):
+            raw = sec[AHDI_SLOT_OFFSETS[i]:AHDI_SLOT_OFFSETS[i] + 12]
+            with self.subTest(slot=i, partition=part.name):
+                want_flag = AHDI_EXISTS_BOOT if i == 0 else AHDI_EXISTS
+                self.assertEqual(slots[i]["flag"], want_flag,
+                                 f"flag{_slot_msg('AHDI', i, raw)}")
+                self.assertEqual(slots[i]["ident"], want_ident,
+                                 f"ident{_slot_msg('AHDI', i, raw)}")
+                self.assertEqual(slots[i]["start_lba"], part.start_lba,
+                                 f"start_lba{_slot_msg('AHDI', i, raw)}")
+                self.assertEqual(slots[i]["size_sectors"], part.size_sectors,
+                                 f"size_sectors{_slot_msg('AHDI', i, raw)}")
+
+        self.assertEqual(sec[510:512], b"\x00\x00")
+
+    def test_xgm_chain_five_partitions(self):
+        # 3 primaries + slot-3 XGM link covering a chain of 2 logicals.
+        # Chain layout: chain_base at LBA 1000; descriptor 0 at 1000, logical 0
+        # at 1001 (size 1024); descriptor 1 at 2025, logical 1 at 2026
+        # (size 2048).
+        primaries = [
+            _make_partition("P1", 16, 32768, start_lba=2),
+            _make_partition("P2", 16, 32768, start_lba=32770),
+            _make_partition("P3", 16, 32768, start_lba=65538),
+        ]
+        log0 = _make_partition("L1", 1, 1024, start_lba=1001, ebr_lba=1000)
+        log1 = _make_partition("L2", 1, 2048, start_lba=2026, ebr_lba=2025)
+        plan = _make_plan(atari_hd.FORMAT_AHDI,
+                          primaries + [log0, log1],
+                          primary_count=3, has_extended=True)
+
+        sec = atari_hd.build_root_sector_ahdi(plan)
+        slots = parse_ahdi_root(sec)
+
+        # Slot 3 is the XGM link.
+        raw3 = sec[AHDI_SLOT_OFFSETS[3]:AHDI_SLOT_OFFSETS[3] + 12]
+        self.assertEqual(slots[3]["flag"], AHDI_EXISTS,
+                         f"XGM flag{_slot_msg('AHDI', 3, raw3)}")
+        self.assertEqual(slots[3]["ident"], b"XGM",
+                         f"XGM ident{_slot_msg('AHDI', 3, raw3)}")
+        # Container: from the first sub-descriptor (1000) through the end
+        # of the last logical (2026 + 2048 = 4074).
+        self.assertEqual(slots[3]["start_lba"], 1000)
+        self.assertEqual(slots[3]["size_sectors"], 4074 - 1000)
+
+        # Now build the descriptors themselves and walk the chain.
+        # Descriptor 0 lives at LBA 1000; the next descriptor is at 2025.
+        chain_base = 1000
+        desc0 = atari_hd.build_xgm_descriptor_sector(
+            logical_abs_start=log0.start_lba,
+            logical_size=log0.size_sectors,
+            logical_ident=b"BGM",
+            desc_abs_lba=log0.ebr_lba,
+            xgm_base_abs_lba=chain_base,
+            next_desc_abs_lba=log1.ebr_lba,
+            next_chain_size=(log1.start_lba + log1.size_sectors) - log1.ebr_lba,
+        )
+        d0 = parse_xgm_descriptor(desc0)
+        self.assertEqual(d0["logical"]["ident"], b"BGM")
+        # Logical's start is RELATIVE to the descriptor's own LBA.
+        self.assertEqual(d0["logical"]["start_lba"],
+                         log0.start_lba - log0.ebr_lba)
+        self.assertEqual(d0["logical"]["size_sectors"], log0.size_sectors)
+        # XGM link's start is RELATIVE to the chain base.
+        self.assertEqual(d0["link"]["ident"], b"XGM")
+        self.assertEqual(d0["link"]["start_lba"], log1.ebr_lba - chain_base)
+
+        # Descriptor 1: end of chain, no link.
+        desc1 = atari_hd.build_xgm_descriptor_sector(
+            logical_abs_start=log1.start_lba,
+            logical_size=log1.size_sectors,
+            logical_ident=b"BGM",
+            desc_abs_lba=log1.ebr_lba,
+            xgm_base_abs_lba=chain_base,
+            next_desc_abs_lba=None,
+            next_chain_size=0,
+        )
+        d1 = parse_xgm_descriptor(desc1)
+        self.assertEqual(d1["logical"]["start_lba"],
+                         log1.start_lba - log1.ebr_lba)
+        self.assertEqual(d1["logical"]["size_sectors"], log1.size_sectors)
+        # End of chain: link slot is empty.
+        self.assertEqual(d1["link"]["flag"], 0)
+        self.assertEqual(d1["link"]["ident"], b"\x00\x00\x00")
+
+
+class TestPpdriverRoot(unittest.TestCase):
+    def test_one_primary(self):
+        p = _make_partition("DATA", size_mb=128, size_sectors=262144,
+                            start_lba=1)
+        plan = _make_plan(atari_hd.FORMAT_PPDRIVER, [p], primary_count=1)
+        sec = atari_hd.build_root_sector_ppdriver(plan)
+        mbr = parse_mbr_root(sec)
+
+        raw0 = sec[MBR_SLOT_OFFSETS[0]:MBR_SLOT_OFFSETS[0] + 16]
+        self.assertEqual(mbr["slots"][0]["boot"], 0x80,
+                         f"P0 boot{_slot_msg('MBR', 0, raw0)}")
+        self.assertEqual(mbr["slots"][0]["part_type"], MBR_TYPE_FAT16,
+                         f"P0 type{_slot_msg('MBR', 0, raw0)}")
+        self.assertEqual(mbr["slots"][0]["rel_start_lba"], 1,
+                         f"P0 start{_slot_msg('MBR', 0, raw0)}")
+        self.assertEqual(mbr["slots"][0]["sector_count"], 262144,
+                         f"P0 size{_slot_msg('MBR', 0, raw0)}")
+
+        for i in (1, 2, 3):
+            with self.subTest(slot=i):
+                self.assertEqual(mbr["slots"][i]["part_type"], 0,
+                                 f"slot {i} should be unused")
+                self.assertEqual(mbr["slots"][i]["sector_count"], 0)
+
+        self.assertEqual(mbr["signature"], b"\x55\xAA")
+
+    def test_four_primaries(self):
+        partitions = [
+            _make_partition("P1", 64, 131072,  start_lba=1),
+            _make_partition("P2", 64, 131072,  start_lba=131073),
+            _make_partition("P3", 64, 131072,  start_lba=262145),
+            _make_partition("P4", 64, 131072,  start_lba=393217),
+        ]
+        plan = _make_plan(atari_hd.FORMAT_PPDRIVER, partitions,
+                          primary_count=4)
+        sec = atari_hd.build_root_sector_ppdriver(plan)
+        mbr = parse_mbr_root(sec)
+
+        for i, part in enumerate(partitions):
+            raw = sec[MBR_SLOT_OFFSETS[i]:MBR_SLOT_OFFSETS[i] + 16]
+            with self.subTest(slot=i, partition=part.name):
+                expected_boot = 0x80 if i == 0 else 0x00
+                self.assertEqual(mbr["slots"][i]["boot"], expected_boot,
+                                 f"boot{_slot_msg('MBR', i, raw)}")
+                self.assertEqual(mbr["slots"][i]["part_type"],
+                                 MBR_TYPE_FAT16,
+                                 f"type{_slot_msg('MBR', i, raw)}")
+                self.assertEqual(mbr["slots"][i]["rel_start_lba"],
+                                 part.start_lba,
+                                 f"start{_slot_msg('MBR', i, raw)}")
+                self.assertEqual(mbr["slots"][i]["sector_count"],
+                                 part.size_sectors,
+                                 f"size{_slot_msg('MBR', i, raw)}")
+        self.assertEqual(mbr["signature"], b"\x55\xAA")
+
+    def test_extended_chain_5_partitions(self):
+        # 3 primaries + extended container in slot 3 covering 2 logicals.
+        primaries = [
+            _make_partition("P1", 64, 131072, start_lba=1),
+            _make_partition("P2", 64, 131072, start_lba=131073),
+            _make_partition("P3", 64, 131072, start_lba=262145),
+        ]
+        log0 = _make_partition("L1", 32, 65536, start_lba=393218, ebr_lba=393217)
+        log1 = _make_partition("L2", 32, 65536, start_lba=458755, ebr_lba=458754)
+        plan = _make_plan(atari_hd.FORMAT_PPDRIVER,
+                          primaries + [log0, log1],
+                          primary_count=3, has_extended=True)
+        sec = atari_hd.build_root_sector_ppdriver(plan)
+        mbr = parse_mbr_root(sec)
+
+        # Slot 3 is the extended container.
+        raw3 = sec[MBR_SLOT_OFFSETS[3]:MBR_SLOT_OFFSETS[3] + 16]
+        ext = mbr["slots"][3]
+        self.assertEqual(ext["part_type"], MBR_TYPE_EXTENDED,
+                         f"ext type{_slot_msg('MBR', 3, raw3)}")
+        # Container spans from the first EBR LBA through the end of the
+        # last logical.
+        ext_start = log0.ebr_lba
+        ext_end = log1.start_lba + log1.size_sectors
+        self.assertEqual(ext["rel_start_lba"], ext_start)
+        self.assertEqual(ext["sector_count"], ext_end - ext_start)
+        self.assertEqual(mbr["signature"], b"\x55\xAA")
+
+        # Build EBR sectors and walk the chain.
+        ext_base = log0.ebr_lba
+        ebr0 = atari_hd.build_ebr_sector(
+            logical_abs_start=log0.start_lba,
+            logical_size=log0.size_sectors,
+            ebr_abs_lba=log0.ebr_lba,
+            ext_base_abs_lba=ext_base,
+            next_ebr_abs_lba=log1.ebr_lba,
+            next_chain_size=(log1.start_lba + log1.size_sectors) - log1.ebr_lba,
+        )
+        e0 = parse_ebr(ebr0)
+        # EBR slot 0: the logical, start RELATIVE to the EBR.
+        self.assertEqual(e0["slots"][0]["part_type"], MBR_TYPE_FAT16)
+        self.assertEqual(e0["slots"][0]["rel_start_lba"],
+                         log0.start_lba - log0.ebr_lba)
+        self.assertEqual(e0["slots"][0]["sector_count"], log0.size_sectors)
+        # EBR slot 1: link to next EBR, start RELATIVE to the chain base.
+        self.assertEqual(e0["slots"][1]["part_type"], MBR_TYPE_EXTENDED)
+        self.assertEqual(e0["slots"][1]["rel_start_lba"],
+                         log1.ebr_lba - ext_base)
+        self.assertEqual(e0["signature"], b"\x55\xAA")
+
+        # Last EBR: no next link.
+        ebr1 = atari_hd.build_ebr_sector(
+            logical_abs_start=log1.start_lba,
+            logical_size=log1.size_sectors,
+            ebr_abs_lba=log1.ebr_lba,
+            ext_base_abs_lba=ext_base,
+            next_ebr_abs_lba=None,
+            next_chain_size=0,
+        )
+        e1 = parse_ebr(ebr1)
+        self.assertEqual(e1["slots"][0]["rel_start_lba"],
+                         log1.start_lba - log1.ebr_lba)
+        # Chain ends: slot 1 cleared.
+        self.assertEqual(e1["slots"][1]["part_type"], 0)
+        self.assertEqual(e1["slots"][1]["rel_start_lba"], 0)
+        self.assertEqual(e1["slots"][1]["sector_count"], 0)
+
+
+class TestHddriverRoot(unittest.TestCase):
+    def test_one_primary_with_overlap_marker(self):
+        p = _make_partition("DATA", size_mb=128, size_sectors=262144,
+                            start_lba=1)
+        plan = _make_plan(atari_hd.FORMAT_HDDRIVER, [p], primary_count=1)
+        sec = atari_hd.build_root_sector_hddriver(plan)
+        mbr = parse_mbr_root(sec)
+
+        # MBR P0: standard FAT16 entry.
+        self.assertEqual(mbr["slots"][0]["boot"], 0x80)
+        self.assertEqual(mbr["slots"][0]["part_type"], MBR_TYPE_FAT16)
+        self.assertEqual(mbr["slots"][0]["rel_start_lba"], 1)
+        self.assertEqual(mbr["slots"][0]["sector_count"], 262144)
+
+        # MBR P1: empty (no extended).
+        self.assertEqual(mbr["slots"][1]["part_type"], 0)
+        self.assertEqual(mbr["slots"][1]["sector_count"], 0)
+
+        # AHDI overlap marker at slot 2 (0x1DE). The TOS view sees the
+        # primary partition starting one sector later (TOS BPB lives at
+        # firstLBA + 1 in the HDDRIVER convention).
+        ahdi_marker = parse_ahdi_entry(sec, 0x1DE)
+        raw_marker = sec[0x1DE:0x1DE + 12]
+        self.assertEqual(ahdi_marker["flag"], AHDI_EXISTS_BOOT,
+                         f"AHDI marker flag{_slot_msg('AHDI@0x1DE', 2, raw_marker)}")
+        self.assertEqual(ahdi_marker["start_lba"], 2,
+                         f"AHDI marker start{_slot_msg('AHDI@0x1DE', 2, raw_marker)}")
+        self.assertEqual(ahdi_marker["size_sectors"], 262143,
+                         f"AHDI marker size{_slot_msg('AHDI@0x1DE', 2, raw_marker)}")
+
+        self.assertEqual(mbr["signature"], b"\x55\xAA")
+
+    def test_extended_chain(self):
+        primary = _make_partition("DATA", 64, 131072, start_lba=1)
+        log0 = _make_partition("L1", 32, 65536, start_lba=131074, ebr_lba=131073)
+        plan = _make_plan(atari_hd.FORMAT_HDDRIVER, [primary, log0],
+                          primary_count=1, has_extended=True)
+        sec = atari_hd.build_root_sector_hddriver(plan)
+        mbr = parse_mbr_root(sec)
+
+        # P0 unchanged, P1 = extended container.
+        self.assertEqual(mbr["slots"][0]["part_type"], MBR_TYPE_FAT16)
+        self.assertEqual(mbr["slots"][1]["part_type"], MBR_TYPE_EXTENDED)
+        self.assertEqual(mbr["slots"][1]["rel_start_lba"], log0.ebr_lba)
+        self.assertEqual(mbr["slots"][1]["sector_count"],
+                         (log0.start_lba + log0.size_sectors) - log0.ebr_lba)
+
+        # AHDI overlap marker still at 0x1DE for the primary.
+        marker = parse_ahdi_entry(sec, 0x1DE)
+        self.assertEqual(marker["flag"], AHDI_EXISTS_BOOT)
+        self.assertEqual(marker["start_lba"], 2)
+        self.assertEqual(marker["size_sectors"], 131071)
+
+        self.assertEqual(mbr["signature"], b"\x55\xAA")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/atari-hd/tests/test_reproducibility.py
+++ b/scripts/atari-hd/tests/test_reproducibility.py
@@ -1,0 +1,116 @@
+"""Reproducibility canary for atari_hd.format_fat16().
+
+The writer commits to a deterministic volume_id seeded from inputs
+(label, size, sector size, sectors-per-cluster, reserved-sectors), so
+the same arguments produce byte-equal output across hosts and runs.
+The contract is quiet -- it would be easy to break and easy to miss.
+
+This module is the alarm that goes off if the seed function ever
+starts reading the wall clock, ingesting host randomness, or losing
+sensitivity to one of its inputs.
+
+Cross-OS stability follows by construction: if the formula is
+pure-Python and reads no clock, the output is bit-identical across
+OSes. We do not need to upload fixture images from one OS to another
+to verify it.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from _support import atari_hd
+
+
+# Baseline inputs to format_fat16(). Sized at 16 MB so it's small enough
+# to format twice per case without slowing the suite, and big enough to
+# satisfy the FAT16 minimum cluster count under every variation below.
+BASELINE = dict(
+    partition_sectors_512=32768,
+    sector_size=512,
+    sectors_per_cluster=2,
+    reserved_sectors=2,
+    label="ATARI",
+    disable_fat_align=True,
+)
+
+
+# Variations tested for sensitivity. Each entry is (case_id, overrides
+# dict). At least one variation per input dimension that participates
+# in _fat16_seed_volume_id (label, partition_sectors_512, sector_size,
+# sectors_per_cluster, reserved_sectors).
+SENSITIVITY_CASES = [
+    ("label",         dict(label="DIFFERENT")),
+    ("size",          dict(partition_sectors_512=40960)),
+    ("sector_size",   dict(sector_size=1024)),
+    ("spc",           dict(sectors_per_cluster=4)),
+    ("res",           dict(reserved_sectors=3)),
+]
+
+
+# Volume serial lives at offset 0x27 in the boot sector; 4 bytes.
+VOL_ID_SLICE = slice(0x27, 0x2B)
+
+
+def _format(tmp, name, **overrides):
+    kwargs = {**BASELINE, **overrides}
+    path = Path(tmp) / f"{name}.img"
+    atari_hd.format_fat16(out_path=str(path), **kwargs)
+    return path.read_bytes()
+
+
+@unittest.skipUnless(hasattr(atari_hd, "format_fat16"),
+                     "atari_hd.format_fat16 not present "
+                     "(epic-001 / story 001 must land first)")
+class TestReproducibility(unittest.TestCase):
+    def test_determinism_byte_equal(self):
+        # Same inputs, two runs, byte-equal output.
+        with tempfile.TemporaryDirectory() as tmp:
+            a = _format(tmp, "a")
+            b = _format(tmp, "b")
+        self.assertEqual(
+            a, b,
+            "format_fat16 is not deterministic: identical inputs "
+            "produced different bytes")
+
+    def test_sensitivity_volume_id_changes_per_dimension(self):
+        # Vary one input at a time; the four volume-serial bytes at
+        # offset 0x27 must differ from the baseline. If they don't,
+        # the seed function has lost sensitivity to that dimension.
+        with tempfile.TemporaryDirectory() as tmp:
+            base = _format(tmp, "baseline")
+            base_vol_id = base[VOL_ID_SLICE]
+            for case_id, overrides in SENSITIVITY_CASES:
+                with self.subTest(varied=case_id):
+                    varied = _format(tmp, case_id, **overrides)
+                    varied_vol_id = varied[VOL_ID_SLICE]
+                    self.assertNotEqual(
+                        varied_vol_id, base_vol_id,
+                        f"varying '{case_id}' did not change volume_id "
+                        f"(base={base_vol_id.hex()}, "
+                        f"varied={varied_vol_id.hex()}); the seed "
+                        "function may have lost sensitivity to that "
+                        "input")
+
+    def test_disable_fat_align_is_currently_a_noop(self):
+        # Story 001 of epic-001 documents disable_fat_align=False as
+        # reserved for future single-BPB variants; today both branches
+        # behave identically. Lock that contract here so that the day
+        # someone wires up the False branch, this test fails loudly and
+        # forces an explicit decision instead of producing silently
+        # different bytes.
+        with tempfile.TemporaryDirectory() as tmp:
+            true_bytes = _format(tmp, "fat_align_true",
+                                 disable_fat_align=True)
+            false_bytes = _format(tmp, "fat_align_false",
+                                  disable_fat_align=False)
+        self.assertEqual(
+            true_bytes, false_bytes,
+            "disable_fat_align is documented as a no-op (epic-001 / "
+            "story 001); flipping the flag must not change output. If "
+            "this test fails, decide whether the new behavior is "
+            "intended and update the docstring + this test together.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/atari-hd/tests/test_round_trip.py
+++ b/scripts/atari-hd/tests/test_round_trip.py
@@ -1,0 +1,127 @@
+"""Round-trip parse-back tests.
+
+Builds a real image via atari_hd.build_image() into a temporary
+directory, then parses the partition table (and any extended chain)
+back from disk and asserts the recovered list matches the plan.
+
+This is the only honest end-to-end check for the writers' offsets,
+chain pointers, and relative-LBA conventions. Each test exercises
+both primary slots and an extended chain (XGM for AHDI, EBR for the
+hybrid formats).
+
+Sizes are chosen to be the smallest the build pipeline accepts:
+  - AHDI partitions can be ~5 MB (single-BPB FAT16 minimum).
+  - PPDRIVER / HDDRIVER partitions need >=32 MB so the synthesized
+    TOS BPB has tos_bps >= 1024 (synthesize_tos_bpb_from_dos512
+    rejects anything smaller).
+
+All artifacts go through tempfile.TemporaryDirectory() so cleanup is
+automatic; nothing is committed to git.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from _support import atari_hd, walk_image
+
+
+# MBR partition type expected for FAT16 primaries / logicals.
+MBR_TYPE_FAT16 = 0x06
+
+
+def _build(plan, tmpdir):
+    """Run atari_hd.build_image() into `tmpdir`. Returns the image path."""
+    plan.image_path = str(Path(tmpdir) / "image.img")
+    atari_hd.build_image(plan)
+    return plan.image_path
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_ahdi_xgm_chain(self):
+        # 5 partitions => layout splits 3 primary + 2 logicals via XGM
+        # chain. Smallest AHDI partition that format_fat16 accepts is
+        # ~5 MB; we use 5 MB across the board.
+        partitions = [
+            atari_hd.Partition(name=f"P{i + 1}", size_mb=5)
+            for i in range(5)
+        ]
+        plan = atari_hd.plan_image(
+            atari_hd.FORMAT_AHDI, image_path="<placeholder>",
+            image_mb=32, partitions=partitions, strict_tos=False)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = _build(plan, tmp)
+            recovered = walk_image(image_path, atari_hd.FORMAT_AHDI)
+
+        self.assertEqual(len(recovered), len(plan.partitions),
+                         f"recovered {len(recovered)} partitions, "
+                         f"expected {len(plan.partitions)}")
+
+        for i, (got, expected) in enumerate(zip(recovered, plan.partitions)):
+            with self.subTest(slot=i, partition=expected.name):
+                self.assertEqual(got["start_lba"], expected.start_lba,
+                                 f"slot {i} start_lba")
+                self.assertEqual(got["size_sectors"], expected.size_sectors,
+                                 f"slot {i} size_sectors")
+                # All AHDI partitions <=32 MB resolve to GEM (first slot
+                # is forced GEM regardless; the rest fall under the 32 MB
+                # threshold for permissive mode).
+                self.assertEqual(got["ident"], b"GEM",
+                                 f"slot {i} ident")
+
+    def test_ppdriver_ebr_chain(self):
+        # 5 partitions => 3 primary + 2 logicals via MBR extended chain.
+        # PPDRIVER hybrid requires partitions large enough for tos_bps
+        # to be >=1024; 32 MB is the smallest size that satisfies that.
+        partitions = [
+            atari_hd.Partition(name=f"P{i + 1}", size_mb=32)
+            for i in range(5)
+        ]
+        plan = atari_hd.plan_image(
+            atari_hd.FORMAT_PPDRIVER, image_path="<placeholder>",
+            image_mb=32 * 5 + 4, partitions=partitions, strict_tos=False)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = _build(plan, tmp)
+            recovered = walk_image(image_path, atari_hd.FORMAT_PPDRIVER)
+
+        self.assertEqual(len(recovered), len(plan.partitions))
+        for i, (got, expected) in enumerate(zip(recovered, plan.partitions)):
+            with self.subTest(slot=i, partition=expected.name):
+                self.assertEqual(got["start_lba"], expected.start_lba,
+                                 f"slot {i} start_lba")
+                self.assertEqual(got["size_sectors"], expected.size_sectors,
+                                 f"slot {i} size_sectors")
+                self.assertEqual(got["part_type"], MBR_TYPE_FAT16,
+                                 f"slot {i} part_type")
+
+    def test_hddriver_ebr_chain(self):
+        # 2 partitions => 1 primary + 1 logical via the MBR extended
+        # chain. HDDRIVER's primary cap is 1, so any N>=2 hits the
+        # extended path. 32 MB partitions for the same hybrid reason.
+        partitions = [
+            atari_hd.Partition(name="BOOT", size_mb=32),
+            atari_hd.Partition(name="DATA", size_mb=32),
+        ]
+        plan = atari_hd.plan_image(
+            atari_hd.FORMAT_HDDRIVER, image_path="<placeholder>",
+            image_mb=72, partitions=partitions, strict_tos=False)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = _build(plan, tmp)
+            recovered = walk_image(image_path, atari_hd.FORMAT_HDDRIVER)
+
+        self.assertEqual(len(recovered), len(plan.partitions))
+        for i, (got, expected) in enumerate(zip(recovered, plan.partitions)):
+            with self.subTest(slot=i, partition=expected.name):
+                self.assertEqual(got["start_lba"], expected.start_lba,
+                                 f"slot {i} start_lba")
+                self.assertEqual(got["size_sectors"], expected.size_sectors,
+                                 f"slot {i} size_sectors")
+                self.assertEqual(got["part_type"], MBR_TYPE_FAT16,
+                                 f"slot {i} part_type")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/atari-hd/tests/test_smoke.py
+++ b/scripts/atari-hd/tests/test_smoke.py
@@ -1,0 +1,19 @@
+"""Smoke test: confirms unittest discovery finds this module and that
+the sys.path bootstrap in _support.py exposes scripts/atari-hd/atari_hd.py
+as the `atari_hd` module."""
+
+import unittest
+
+from _support import atari_hd
+
+
+class TestSmoke(unittest.TestCase):
+    def test_atari_hd_exposes_format_fat16(self):
+        # format_fat16 is the keystone landed by epic-001; if the suite
+        # can see it, every story 002+ test will be able to as well.
+        self.assertTrue(hasattr(atari_hd, "format_fat16"),
+                        "atari_hd.format_fat16 missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Lands a stdlib-only `unittest` test suite for `scripts/atari-hd/atari_hd.py`
plus a GitHub Actions workflow that runs it on every PR / push to main.
Implements all 9 stories of epic-002.

- 8 test modules / 36 tests covering geometry, partition-table writers,
  cap rules, end-to-end round-trip via `build_image`, FAT16 writer
  fields, dual-BPB invariants, and the deterministic-`volume_id`
  contract.
- New `_support.py` provides parsers (`parse_ahdi_root`, `parse_mbr_root`,
  `parse_ebr`, `parse_xgm_descriptor`, `parse_bpb`) and a chain walker
  (`walk_image`) used across the suite.
- New `.github/workflows/test-atari-hd.yml` matrix-runs the suite on
  Ubuntu / macOS / Windows × Python 3.10 / 3.12 with a `paths:` filter
  scoped to `scripts/atari-hd/**` so RP firmware-only PRs don't burn
  minutes.

## Commits

```
5632bc5 atari-hd tests: GitHub Actions workflow (epic-002 / story 009)
e6eaff5 atari-hd tests: reproducibility canary (epic-002 / story 008)
3ee8711 atari-hd tests: dual-BPB invariant locks (epic-002 / story 007)
530c597 atari-hd tests: FAT16 writer field locks (epic-002 / story 006)
3b11401 atari-hd tests: round-trip parse-back via build_image (epic-002 / story 005)
695d5c3 atari-hd tests: cap & layout enforcement (epic-002 / story 004)
2e438dd atari-hd tests: partition-table writer locks (epic-002 / story 003)
1bd4a93 atari-hd tests: lock predict_mkfs_spfat formula (epic-002 / story 002)
244161b atari-hd tests: scaffolding & shared helpers (epic-002 / story 001)
```

Net delta vs. `main`: +1676 lines across 12 new files. Zero changes to
production code (`atari_hd.py` is untouched).

## Coverage

| Module | Locks |
|---|---|
| `test_smoke` | suite discovery + `atari_hd` import |
| `test_geometry` | `predict_mkfs_spfat()` against a 16-row fixture table |
| `test_partition_tables` | AHDI root (N=1..4 + XGM chain), PPDRIVER MBR + EBR chain, HDDRIVER P0 + AHDI overlap marker + EBR chain |
| `test_caps` | per-slot caps, GEM/BGM threshold, primary/extended split, rejection paths |
| `test_round_trip` | end-to-end via `build_image` for all three formats with extended chains |
| `test_fat16_writer` | every BPB field across 6 fixtures (single-BPB + dual-BPB + sector_size > 512), FAT[0..3] + both copies, root-dir layout, data area sampled |
| `test_dual_bpb` | the six invariants across `{PPDRIVER, HDDRIVER} × {2, 4, 8, 16}` ratios |
| `test_reproducibility` | determinism + sensitivity per seed input + `disable_fat_align` no-op contract |

## Test plan

- [x] `python -m unittest discover scripts/atari-hd/tests -v` runs 36
      tests in ~9 s on macOS, all green.
- [x] `parity.py` from epic-001 still standalone; `unittest discover`
      ignores it (only matches `test_*.py`).
- [x] Stdlib only — no third-party imports anywhere under
      `scripts/atari-hd/tests/`. No `pip install` step in the workflow.
- [x] No fixtures committed; every artifact lives under
      `tempfile.TemporaryDirectory()`.
- [ ] First green workflow run on each matrix cell observed in the
      Actions UI (Ubuntu, macOS, Windows × Python 3.10, 3.12).
- [ ] **Repo-admin step:** add the workflow as a required status check
      for `main` in branch protection settings. This can't be expressed
      inside the repo.

## Notes for reviewers

- Two soft deviations from the per-story specs, called out in commit
  messages:
  - **Story 005** uses 32 MB partitions for PPDRIVER / HDDRIVER fixtures
    (vs. the spec's "≤ 8 MB") because `synthesize_tos_bpb_from_dos512`
    rejects `tos_bps < 1024`. Runtime stayed under 1.5 s for that
    module so the spirit of "tiny / fast" holds.
  - **Story 007** drops `ratio=1` from the `{1, 2, 4, 8, 16}` set
    because the dual-BPB synthesis hard-rejects `tos_bps < 1024` —
    the configuration cannot be constructed.
- Tests use the private helpers `atari_hd._fat16_compute_spfat` and
  `atari_hd._fat16_seed_volume_id` as the source of truth for derived
  values. Underscore-prefixed but module-internal; calling them from
  tests is the cleanest way to avoid hard-coding magic numbers that
  would drift independently.
- The `_walk_mbr` helper deliberately *skips* HDDRIVER's AHDI overlap
  marker at offset `0x1DE`. The marker bytes happen to be parseable as
  an MBR slot 2 with `part_type = 0` for the partition LBAs we test,
  so the walker does the right thing — but a future HDDRIVER fixture
  with start_lba > 16 MiB could trip this. Worth flagging if you ever
  extend the round-trip fixtures.