### PR TITLE
atari-hd: TUI + post-story hardware fidelity (epic-003)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,16 @@ On-demand only. Boot does no unconditional STA init. `APP_MODE_NTP_INIT` in `emu
 
 Keep `AGENTS.md` updated when new workflow rules or hardware gotchas are discovered.
 
+## Hard-disk specs: validate against the Atari Compendium via `/notebooklm`
+
+When working on Atari ST hard-disk on-disk formats — partition tables (AHDI / MBR / XGM / EBR), partition idents (GEM / BGM / XGM), the FAT16 BPB used by TOS, the dual-BPB hybrid layout used by PPDRIVER / HDDRIVER, partition-size caps and TOS-version rules, or any related low-level detail — use the `/notebooklm` skill against the **Atari ST/STE/TT/Falcon — Technical Reference** notebook as the source of truth before making non-trivial claims in code or docs. The notebook indexes the Atari Compendium and related references; the skill opens a fresh browser session per question.
+
+Applies anywhere these surfaces are touched: `scripts/atari-hd/atari_hd.py`, `scripts/atari-hd/tui/`, `rp/src/acsi.c`, `target/atarist/src/acsi.s`, the test suite under `scripts/atari-hd/tests/`, and any docstring or `CLAUDE.md` / `README.md` that describes the on-disk format.
+
+Workflow: ask focused questions, follow up on gaps (each NotebookLM answer ends with "Is that ALL you need to know?" — read it and decide), then record the non-obvious conclusions in a docstring or comment so the next reader doesn't have to re-validate.
+
+Drift example we already caught with this skill: the "first AHDI partition must be GEM" rule was framed as a TOS boot rule across `atari_hd.py`, the TUI, the test suite and the README. The Compendium clarifies that TOS itself only checks the boot flag (bit 7 of the AHDI flag byte); the GEM-on-slot-0 clamp is a *legacy-driver* compatibility default (original AHDI / SCSI Tools required it; modern drivers — HDDRIVER, PPDRIVER, ICD Pro — accept BGM boot up to 512 MB). The clamp stayed in the code but the framing was corrected. That's the kind of mistake this validation step exists to catch.
+
 ## Editing guardrails
 
 - **Never modify** `pico-sdk/`, `pico-extras/`, or `fatfs-sdk/` — they are git submodules pinned to specific upstream revisions, and the build re-pins them on every run. To change FatFs configuration, edit `rp/src/ff/ffconf.h` (project-owned override); the include path is set up via `target_include_directories(... BEFORE PRIVATE)` so this file wins over the submodule's default.

--- a/scripts/atari-hd/README.md
+++ b/scripts/atari-hd/README.md
@@ -81,8 +81,13 @@ partitions more tightly than TOS 1.04+:
 
 | Mode | GEM cap (boot + small partitions) | BGM cap (big partitions) |
 |------|:--------------------------------:|:-----------------------:|
-| TOS 1.04+ (default) | 32 MB | 512 MB |
+| TOS 1.04+ (default) | 32 MB | 511 MB |
 | TOS < 1.04 (strict) | 16 MB | 256 MB |
+
+The "512 MB" figure quoted in much of the AHDI literature is rounded
+up: the real ceiling is `NSECTS = 65535` at `bps = 8192` =
+**511.99 MB**. A 512 MB BGM partition trips the Hatari sector-doubling
+rule into `bps = 16384`, which TOS 1.04 - 3.x doesn't support.
 
 Say yes to the compat prompt if you're writing an image for a 520ST /
 1040ST / Mega ST still running the original TOS; otherwise leave it at
@@ -92,10 +97,10 @@ the default. The choice:
   (16 or 32 MB). This is a defensive compatibility default for the
   legacy boot path — original AHDI and early SCSI Tools required GEM
   on the boot slot. TOS itself only checks the boot flag, and modern
-  drivers (HDDRIVER, PPDRIVER, ICD Pro) accept BGM boot up to 512 MB,
+  drivers (HDDRIVER, PPDRIVER, ICD Pro) accept BGM boot up to 511 MB,
   but emitting GEM at slot 0 is what works everywhere. The cap just
   changes with the strict-vs-permissive mode.
-- Caps subsequent partitions at the BGM size (256 or 512 MB). Slots
+- Caps subsequent partitions at the BGM size (256 or 511 MB). Slots
   2..N can still be GEM (within the GEM cap) or BGM.
 - Is surfaced in the summary (`TOS compat : ...`) so you can verify
   before confirming.

--- a/scripts/atari-hd/README.md
+++ b/scripts/atari-hd/README.md
@@ -81,7 +81,7 @@ partitions more tightly than TOS 1.04+:
 
 | Mode | GEM cap (boot + small partitions) | BGM cap (big partitions) |
 |------|:--------------------------------:|:-----------------------:|
-| TOS 1.04+ (default) | 32 MB | 511 MB |
+| TOS 1.04+ (default) | 31 MB | 511 MB |
 | TOS < 1.04 (strict) | 16 MB | 256 MB |
 
 The "512 MB" figure quoted in much of the AHDI literature is rounded
@@ -94,7 +94,7 @@ Say yes to the compat prompt if you're writing an image for a 520ST /
 the default. The choice:
 
 - **Forces partition 1 to be a GEM entry**, capped at the GEM size
-  (16 or 32 MB). This is a defensive compatibility default for the
+  (16 or 31 MB). This is a defensive compatibility default for the
   legacy boot path — original AHDI and early SCSI Tools required GEM
   on the boot slot. TOS itself only checks the boot flag, and modern
   drivers (HDDRIVER, PPDRIVER, ICD Pro) accept BGM boot up to 511 MB,

--- a/scripts/atari-hd/README.md
+++ b/scripts/atari-hd/README.md
@@ -88,10 +88,13 @@ Say yes to the compat prompt if you're writing an image for a 520ST /
 1040ST / Mega ST still running the original TOS; otherwise leave it at
 the default. The choice:
 
-- **Forces partition 1 (the TOS boot partition) to be a GEM entry**
-  capped at the GEM size (16 or 32 MB). TOS only boots from GEM, so this
-  is a hard constraint regardless of your answer to the compat prompt —
-  the cap just changes with the mode.
+- **Forces partition 1 to be a GEM entry**, capped at the GEM size
+  (16 or 32 MB). This is a defensive compatibility default for the
+  legacy boot path — original AHDI and early SCSI Tools required GEM
+  on the boot slot. TOS itself only checks the boot flag, and modern
+  drivers (HDDRIVER, PPDRIVER, ICD Pro) accept BGM boot up to 512 MB,
+  but emitting GEM at slot 0 is what works everywhere. The cap just
+  changes with the strict-vs-permissive mode.
 - Caps subsequent partitions at the BGM size (256 or 512 MB). Slots
   2..N can still be GEM (within the GEM cap) or BGM.
 - Is surfaced in the summary (`TOS compat : ...`) so you can verify

--- a/scripts/atari-hd/README.md
+++ b/scripts/atari-hd/README.md
@@ -28,7 +28,7 @@ primaries vs. how many have to live in an extended chain:
 | Format | Max primary | Primary slots | Extended chain type | When extended kicks in |
 |--------|------------:|---------------|---------------------|------------------------|
 | AHDI | 4 | AHDI root slots 0..3 at 0x1C6 / 0x1D2 / 0x1DE / 0x1EA | XGM (AHDI-native) | N > 4: use slots 0..2 as primaries, slot 3 as the XGM chain head |
-| PPDRIVER | 4 | MBR P0..P3 at 0x1BE..0x1EE | MBR extended (type 0x0F) | N > 4: use P0..P2 as primaries, P3 as the extended container |
+| PPDRIVER | 1 | MBR P0 only at 0x1BE | MBR extended (type 0x0F) | N > 1: MBR P0 primary + MBR P1 extended container (matches PPTOSDOS convention; multi-primary fails on real Atari hardware at >256 MB partition sizes) |
 | HDDRIVER | 1 | MBR P0 only (AHDI slot 2 at 0x1DE carries the TOS overlap marker and consumes the slot where MBR P2 would live) | MBR extended (type 0x0F) | N > 1: MBR P0 primary + MBR P1 extended container |
 
 For AHDI, each XGM sub-descriptor sector follows the Atari convention:

--- a/scripts/atari-hd/README.md
+++ b/scripts/atari-hd/README.md
@@ -132,6 +132,15 @@ always uses 512-byte sectors (so macOS mounts them), the TOS companion BPB
 uses the larger Hatari-picked sector size, and both BPBs project onto the
 same physical FAT/root/data regions.
 
+> ⚠️ **PPDRIVER / HDDRIVER primary-slot rule.** The single MBR primary
+> (slot 0) is capped at **255 MB** (TOS bps ≤ 4096). Real PPDRIVER and
+> real HDDRIVER on Atari hardware fail to read primary partitions whose
+> TOS BPB carries `bps>4096`; logicals in the extended chain are
+> unaffected and get the full 511 MB cap. To make a >255 MB hybrid
+> image, add a small primary (e.g. 32 MB BOOT) and put the bulk in the
+> extended chain — that's what real PPDRIVER's setup tool produces.
+> Verified empirically + against real reference images.
+
 ### macOS compatibility
 
 **PPDRIVER and HDDRIVER images mount on macOS at any supported size.** The

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -1570,7 +1570,12 @@ def _partition_from_entry(image_path: str, image_size: int, entry: dict,
     regardless of format."""
     size_sec = entry["size_sectors"]
     size_mb = (size_sec * SECTOR_SIZE) // MIB
-    default = f"P{slot_index + 1}"
+    # Default name reflects the slot's role: primaries get "P<N+1>",
+    # extended/chain logicals get "E<N+1>". Matches the TUI dialog's
+    # _default_label so a partition that arrived without a BPB label
+    # comes back with the same name shape it would have if the user
+    # had created it freshly.
+    default = f"{'E' if ebr_lba else 'P'}{slot_index + 1}"
     name = _label_from_bpb(image_path, entry["start_lba"], image_size,
                             default=default)
     p = Partition(name=name, size_mb=size_mb,
@@ -1597,7 +1602,7 @@ def _partition_from_mbr(image_path: str, image_size: int,
     can put primaries back at MBR slots and logicals back in the
     extended chain."""
     size_mb = (size_sectors * SECTOR_SIZE) // MIB
-    default = f"P{slot_index + 1}"
+    default = f"{'E' if ebr_lba else 'P'}{slot_index + 1}"
     name = _label_from_bpb(image_path, start_lba, image_size,
                             default=default)
     p = Partition(name=name, size_mb=size_mb,

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -23,6 +23,7 @@ extended with the hybrid layouts used by real Atari hard disk drivers.
 Usage: interactive. Run with no arguments.
 """
 
+import argparse
 import hashlib
 import os
 import struct
@@ -2292,5 +2293,55 @@ def main() -> int:
     return 0
 
 
+# --------------------------------------------------------------------------
+# TUI / prompt-mode launcher (epic-003 / story 009)
+# --------------------------------------------------------------------------
+
+def _parse_args(argv=None):
+    """Parse the launcher's two TUI/prompt selector flags. argparse
+    auto-rejects --tui --no-tui together via the mutually-exclusive
+    group, so we don't have to."""
+    p = argparse.ArgumentParser(
+        prog="atari_hd.py",
+        description=("Build Atari ST hard-disk images "
+                     "(AHDI / PPDRIVER / HDDRIVER)."),
+        epilog=("Default: TUI when both stdin and stdout are a "
+                "terminal; otherwise the linear prompt flow."))
+    g = p.add_mutually_exclusive_group()
+    g.add_argument(
+        "--tui", action="store_true",
+        help=("Force the terminal UI even when stdin/stdout are not "
+              "a TTY (mainly for debug)."))
+    g.add_argument(
+        "--no-tui", action="store_true",
+        help="Force the linear prompt flow even on a TTY.")
+    return p.parse_args(argv)
+
+
+def _should_use_tui(args) -> bool:
+    """Resolve the TUI-vs-prompt choice. Explicit flags win; otherwise
+    require *both* stdin and stdout to be TTYs (the TUI has nothing to
+    draw on a redirected stdout, and read_key() would spin on a
+    redirected stdin)."""
+    if args.tui:
+        return True
+    if args.no_tui:
+        return False
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _run_tui() -> int:
+    """Launch the TUI. Lazy-imports the tui package so prompt-mode
+    invocations don't pay its startup cost."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    if here not in sys.path:
+        sys.path.insert(0, here)
+    from tui.app import main as tui_main
+    return tui_main()
+
+
 if __name__ == "__main__":
+    args = _parse_args()
+    if _should_use_tui(args):
+        sys.exit(_run_tui())
     sys.exit(main())

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -67,10 +67,19 @@ MIN_PARTITION_MB = 2
 AHDI_MAX_PARTITION_MB_STRICT = 256   # TOS < 1.04 BGM cap
 AHDI_MAX_PARTITION_MB = 511          # TOS 1.04+ BGM cap (was 512; off by one)
 
-# Threshold for AHDI's GEM vs. BGM partition-id choice. <= threshold uses
-# "GEM" (small partition); above uses "BGM" (big).
+# GEM partition cap. AHDI 3.0 / Atari Compendium: ident=GEM strictly
+# implies bps=512; ident=BGM strictly implies bps>512. The cap is the
+# largest size that choose_logical_sector_size keeps at bps=512:
+# clusters at spc=2 must stay <= 32765, so sec_512 <= 65530, i.e.
+# <= 31.99 MB rounded down to 31. The literature commonly quotes
+# "32 MB GEM" but a 32 MB partition lands at bps=1024 by the Hatari
+# doubling rule, which makes it a BGM (mismatching the GEM ident).
+# Mixing ident=GEM with bps>512 is malformed; AHDI / SCSI Tools and
+# similar legacy drivers may corrupt past the first 32 MB of physical
+# sectors. Validated against the Atari Compendium notebook (see
+# CLAUDE.md).
 AHDI_GEM_MAX_MB_STRICT = 16          # TOS < 1.04 GEM cap
-AHDI_GEM_MAX_MB = 32                 # TOS 1.04+ GEM cap
+AHDI_GEM_MAX_MB = 31                 # TOS 1.04+ GEM cap (was 32; off by one)
 
 # Caps for the PPDRIVER / HDDRIVER dual-BPB hybrid layout. Both ends
 # come from the TOS-side BPB, NOT the DOS view:
@@ -334,8 +343,7 @@ def build_root_sector_ahdi(plan: "ImagePlan") -> bytes:
         part = plan.partitions[i]
         flag = AHDI_FLAG_EXISTENT | (AHDI_FLAG_BOOTABLE if i == 0 else 0)
         write_ahdi_entry(buf, ahdi_offsets[i], flag,
-                         ahdi_partition_id(part.size_mb, plan.strict_tos,
-                                           is_first=(i == 0)),
+                         ahdi_partition_id(part.size_mb),
                          part.start_lba, part.size_sectors)
 
     if plan.has_extended:
@@ -1082,14 +1090,16 @@ def partition_cap_mb(format_id: str, strict_tos: bool,
     """Per-slot partition-size cap.
 
     On AHDI we conservatively treat the first partition as the boot
-    partition and clamp it to the GEM cap (16 MB strict / 32 MB
+    partition and clamp it to the GEM cap (16 MB strict / 31 MB
     permissive) for legacy-driver compatibility. This is *not* a TOS
     rule per se -- TOS itself only checks the boot flag, and modern
     drivers boot from BGM up to 511 MB -- but the original AHDI and
-    early SCSI Tools required the GEM clamp, so we keep it. See
-    ahdi_partition_id() for the full rationale. Slots 2..N can be GEM
-    (within the same threshold) or BGM (up to 256/511). Hybrid formats
-    have no per-slot distinction."""
+    early SCSI Tools required the GEM clamp, so we keep it. The cap
+    also keeps slot 0 in the bps=512 region (where ident=GEM is
+    correct) -- ident strictly follows bps in ahdi_partition_id(),
+    so a slot-0 partition above this cap would mismatch its BPB.
+    Slots 2..N can be GEM (within the same cap) or BGM (up to
+    256/511). Hybrid formats have no per-slot distinction."""
     if format_id == FORMAT_AHDI and partition_index == 0:
         return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
     return format_max_partition_mb(format_id, strict_tos)
@@ -1845,35 +1855,40 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
     return plan
 
 
-def ahdi_partition_id(partition_mb: int, strict_tos: bool = False,
-                      is_first: bool = False) -> bytes:
-    """Pick the AHDI partition-id bytes for a partition of `partition_mb` MB.
+def ahdi_partition_id(partition_mb: int) -> bytes:
+    """Pick the AHDI partition ident strictly from the partition's
+    logical sector size (which choose_logical_sector_size derives from
+    its 512-byte sector count).
 
-    `is_first=True` forces b"GEM" regardless of size. This is a
-    *defensive compatibility* choice rather than a hard TOS requirement:
-    TOS itself only checks the boot flag (bit 7 of the partition-entry
-    flag byte), not the ident; modern drivers (HDDRIVER, PPDRIVER, ICD
-    Pro) happily boot from BGM up to 511 MB. But the original AHDI and
-    early SCSI Tools required ident == GEM and size <= 16 MB on the
-    boot slot, so emitting GEM at slot 0 is the broadest-compatibility
-    pick. Removing this clamp would let the user set up a 511 MB BGM
-    boot partition that works on modern drivers but fails on legacy
-    ones; revisit if a workflow actually wants that.
+    Per AHDI 3.0 / the Atari Compendium (validated against the
+    Compendium notebook -- see CLAUDE.md):
+      - GEM is the small-partition ident: bps == 512.
+      - BGM (Big GEM) is the large-sector ident: bps > 512.
+      - Mixing the two -- ident=GEM with bps>512, or ident=BGM with
+        bps=512 -- is technically malformed. Legacy drivers (original
+        AHDI, SCSI Tools) may refuse to mount or corrupt data past
+        the first 32 MB of physical sectors when they see ident=GEM
+        but the BPB reports bps>512.
 
-    Later partitions use the usual threshold: GEM when partition_mb is
-    <= the TOS-version GEM cap, BGM otherwise. Note that the underlying
-    distinction is sector-size driven (GEM = bps 512, BGM = bps > 512);
-    the size threshold is what causes choose_logical_sector_size() to
-    flip bps, so size and ident move together.
+    The choose_logical_sector_size() doubling rule keeps bps=512 only
+    while clusters_at_spc2 <= 32765, i.e. partition_sec_512 <= 65530
+    (~31.99 MB). At 32 MB it doubles to bps=1024. So:
+      - <= 31 MB: bps=512, ident=GEM
+      - >= 32 MB: bps>=1024, ident=BGM
 
-    The GEM/BGM threshold differs between TOS versions: original TOS
-    (< 1.04) accepts GEM only up to 16 MB, while TOS 1.04+ extends that
-    to 32 MB. `strict_tos=True` requests the conservative pre-1.04
-    rule."""
-    if is_first:
-        return b"GEM"
-    threshold = AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
-    return b"GEM" if partition_mb <= threshold else b"BGM"
+    Earlier revisions of this function accepted an `is_first` flag
+    that forced b"GEM" at slot 0 regardless of size. That force is
+    gone -- the GEM-on-slot-0 invariant for legacy-driver boot
+    compatibility is preserved by capping slot 0 at AHDI_GEM_MAX_MB
+    (31 MB permissive / 16 MB strict) via partition_cap_mb(), so any
+    partition that lands at slot 0 naturally falls in the GEM region
+    and ident=GEM picked here is consistent with the BPB's bps=512.
+    Forcing GEM at slot 0 with size 32 MB would have produced the
+    malformed combination flagged above.
+    """
+    sec_512 = mb_to_sectors_512(partition_mb)
+    bps = choose_logical_sector_size(sec_512)
+    return b"GEM" if bps == 512 else b"BGM"
 
 
 def build_image(plan: ImagePlan, progress=None) -> None:
@@ -1984,9 +1999,7 @@ def build_image(plan: ImagePlan, progress=None) -> None:
                 desc = build_xgm_descriptor_sector(
                     logical_abs_start=part.start_lba,
                     logical_size=part.size_sectors,
-                    logical_ident=ahdi_partition_id(part.size_mb,
-                                                    plan.strict_tos,
-                                                    is_first=False),
+                    logical_ident=ahdi_partition_id(part.size_mb),
                     desc_abs_lba=part.ebr_lba,
                     xgm_base_abs_lba=chain_base,
                     next_desc_abs_lba=next_desc_abs,
@@ -2076,7 +2089,7 @@ def ask_tos_compat() -> bool:
     print()
     print("TOS < 1.04 was the original TOS shipped with early machines")
     print("(520ST, 1040ST, Mega ST). It caps AHDI partitions tighter:")
-    print("   - GEM <= 16 MB   (vs 32 MB on TOS 1.04+)")
+    print("   - GEM <= 16 MB   (vs 31 MB on TOS 1.04+)")
     print("   - BGM <= 256 MB  (vs 511 MB on TOS 1.04+)")
     return ask_yes_no(
         "Force compatibility with TOS < 1.04 "
@@ -2164,9 +2177,7 @@ def print_summary(plan: ImagePlan) -> None:
     print(header)
     print("   " + "-" * (len(header) - 3))
     for i, part in enumerate(plan.partitions, start=1):
-        is_first = (i == 1) and (plan.format_id == FORMAT_AHDI)
-        ahdi_tag = ahdi_partition_id(part.size_mb, plan.strict_tos,
-                                     is_first=is_first).decode() \
+        ahdi_tag = ahdi_partition_id(part.size_mb).decode() \
             if plan.format_id in (FORMAT_AHDI, FORMAT_HDDRIVER) else "-"
         tos_tag = str(part.tos_bps) if part.tos_bps else "-"
         print(f"   {i:>2}  {part.name:<11}  {part.size_mb:>8}  "

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -45,20 +45,46 @@ FORMAT_HDDRIVER = "HDDRIVER"
 
 # Limits
 MIN_IMAGE_MB = 2              # absolute floor; mkfs.vfat refuses smaller
-MAX_PARTITION_MB = 2048       # FAT16 ceiling with 32 KB clusters
+# FAT16 theoretical ceiling with 32 KB clusters; only reachable on
+# Falcon TOS 4.x (which supports bps=16384/32768). On ST/STE/Mega ST/TT
+# (TOS 1.04 - 3.x) the practical ceiling is the hybrid cap below.
+MAX_PARTITION_MB = 2048
 MIN_PARTITION_MB = 2
 
 # AHDI partition-size caps imposed by the TOS kernel's BGM handling. These
-# are only enforced on the AHDI path (the hybrid formats go through the
-# DOS view which doesn't care). "Strict" = TOS < 1.04 (520ST / 1040ST /
-# Mega ST running the original TOS). Permissive = TOS 1.04 and later.
+# are only enforced on the AHDI path (the hybrid formats use their own
+# caps below). "Strict" = TOS < 1.04 (520ST / 1040ST / Mega ST running the
+# original TOS). Permissive = TOS 1.04 and later.
+#
+# The permissive cap was historically quoted as 512 MB (= 65536 logical
+# sectors x 8192 bps) but TOS reads NSECTS as 16-bit unsigned, so the
+# real ceiling is 65535 sectors -> 511.99 MB rounded down to 511. Real
+# AHDI partitions of exactly 512 MB don't build in our pipeline (they
+# trip the Hatari sector-doubling rule into bps=16384, which TOS
+# 1.04 - 3.x doesn't support). Validated against the Atari Compendium
+# notebook; see CLAUDE.md and HYBRID_MAX_PARTITION_MB below.
 AHDI_MAX_PARTITION_MB_STRICT = 256   # TOS < 1.04 BGM cap
-AHDI_MAX_PARTITION_MB = 512          # TOS 1.04+ BGM cap
+AHDI_MAX_PARTITION_MB = 511          # TOS 1.04+ BGM cap (was 512; off by one)
 
 # Threshold for AHDI's GEM vs. BGM partition-id choice. <= threshold uses
 # "GEM" (small partition); above uses "BGM" (big).
 AHDI_GEM_MAX_MB_STRICT = 16          # TOS < 1.04 GEM cap
 AHDI_GEM_MAX_MB = 32                 # TOS 1.04+ GEM cap
+
+# Caps for the PPDRIVER / HDDRIVER dual-BPB hybrid layout. Both ends
+# come from the TOS-side BPB, NOT the DOS view:
+#   - MAX: TOS reads the partition's total-sectors-16 field (NSECTS) as
+#     a 16-bit unsigned value (max 65535). At the maximum supported TOS
+#     logical sector size of 8192 bytes (TOS 1.04 - 3.x; Falcon TOS 4.x
+#     could go to 16384/32768 but isn't a target here), that's
+#     65535 x 8192 = 511.99 MB, rounded down to 511 MB.
+#   - MIN: the hybrid synthesis requires tos_bps >= 1024 (ratio >= 2).
+#     The Hatari sector-doubling rule first reaches ratio=2 at
+#     ~32 MB; below that, choose_logical_sector_size leaves bps=512
+#     and synthesize_tos_bpb_from_dos512 rejects the plan.
+# Validated against the Atari Compendium notebook; see CLAUDE.md.
+HYBRID_MAX_PARTITION_MB = 511
+HYBRID_MIN_PARTITION_MB = 32
 
 # mkfs behavior: sectors per cluster fixed at 2 (matches Hatari's script and
 # real HDDRIVER/PPDRIVER images we've seen on disk).
@@ -72,10 +98,22 @@ AHDI_SLOT3_OFFSET = 0x01EA
 AHDI_ENTRY_SIZE = 12
 AHDI_FLAG_EXISTENT = 0x01
 AHDI_FLAG_BOOTABLE = 0x80
+# AHDI 3.0 'hd_siz' field: total disk size in 512-byte sectors,
+# 4 bytes big-endian. Documented but optional; modern drivers
+# (HDDRIVER, ICD Pro) ignore it. We populate it on pure-AHDI images
+# for byte-level fidelity with real AHDI tooling. NOT applicable to
+# the hybrid layouts (PPDRIVER / HDDRIVER) -- the MBR partition
+# table at 0x1BE..0x1FD overlaps these bytes.
+AHDI_HD_SIZ_OFFSET = 0x01C2
 
 # MBR partition-table offsets
 MBR_P0_OFFSET = 0x01BE
 MBR_SIGNATURE_OFFSET = 510
+# Disk signature (Windows NT-style 4-byte ID). Real PPDRIVER images
+# stamp a random value here; HDDRIVER leaves it at zero. We seed
+# PPDRIVER's deterministically from plan inputs (same hash-of-inputs
+# approach as the FAT16 volume_id) so output stays reproducible.
+MBR_DISK_SIGNATURE_OFFSET = 0x01B8
 MBR_SIGNATURE = bytes((0x55, 0xAA))
 
 # BPB field offsets inside a boot sector (Hatari/DOS convention)
@@ -130,9 +168,27 @@ DEFAULT_IMAGE_MB = {
     FORMAT_HDDRIVER: 2048,
 }
 
-# MBR partition type for extended containers (LBA-addressable variant).
+# MBR partition type bytes.
+#
+# FAT16 type: PPDRIVER and HDDRIVER both emit 0x06 (FAT16B / "BIGDOS";
+# >= 32 MB) for their primary FAT16 partitions. Sub-32 MB partitions
+# would conventionally be 0x04 (FAT16A); we don't generate those
+# because the hybrid min cap is 32 MB. AHDI is unaffected (no MBR).
 MBR_TYPE_FAT16 = 0x06
-MBR_TYPE_EXTENDED = 0x0F
+#
+# Extended-container type: PPDRIVER uses 0x0F (Win95 LBA-addressable
+# extended) to force LBA addressing on large disks. HDDRIVER uses
+# 0x05 (CHS extended FAT16B). Real PPDRIVER and HDDRIVER images
+# byte-mismatch on this single field; we honor each driver's choice.
+# Validated against the Atari Compendium notebook; see CLAUDE.md.
+MBR_TYPE_EXTENDED_LBA = 0x0F
+MBR_TYPE_EXTENDED_CHS = 0x05
+# Back-compat alias used by existing callers / tests; defaults to the
+# LBA variant which is what build_ebr_sector also defaults to.
+MBR_TYPE_EXTENDED = MBR_TYPE_EXTENDED_LBA
+# Extended-container types the loader / walker recognises (either LBA
+# or CHS) so we can read both PPDRIVER and HDDRIVER images.
+MBR_EXTENDED_TYPES = (MBR_TYPE_EXTENDED_LBA, MBR_TYPE_EXTENDED_CHS)
 
 
 # --------------------------------------------------------------------------
@@ -214,7 +270,8 @@ def write_mbr_entry(buf: bytearray, offset: int, boot: int, part_type: int,
 def build_ebr_sector(logical_abs_start: int, logical_size: int,
                      ebr_abs_lba: int, ext_base_abs_lba: int,
                      next_ebr_abs_lba: Optional[int],
-                     next_chain_size: int) -> bytes:
+                     next_chain_size: int,
+                     extended_type: int = MBR_TYPE_EXTENDED_LBA) -> bytes:
     """Build a 512-byte Extended Boot Record.
 
     EBR layout:
@@ -225,6 +282,10 @@ def build_ebr_sector(logical_abs_start: int, logical_size: int,
         (= the absolute LBA of the first EBR).
       - slots 2/3 left empty.
       - 0x55AA signature at byte 510.
+
+    `extended_type` controls slot 1's type byte for the next-EBR link.
+    PPDRIVER uses 0x0F (LBA); HDDRIVER uses 0x05 (CHS). Default 0x0F
+    matches PPDRIVER and the test fixtures from epic-002.
 
     If `next_ebr_abs_lba` is None this is the last EBR in the chain and
     slot 1 is left zero.
@@ -237,7 +298,7 @@ def build_ebr_sector(logical_abs_start: int, logical_size: int,
     # Slot 1: link to the next EBR, if the chain continues.
     if next_ebr_abs_lba is not None:
         write_mbr_entry(buf, MBR_P0_OFFSET + 16, boot=0x00,
-                        part_type=MBR_TYPE_EXTENDED,
+                        part_type=extended_type,
                         start_lba=next_ebr_abs_lba,
                         sector_count=next_chain_size,
                         rel_start_lba=next_ebr_abs_lba - ext_base_abs_lba)
@@ -281,6 +342,12 @@ def build_root_sector_ahdi(plan: "ImagePlan") -> bytes:
         write_ahdi_entry(buf, ahdi_offsets[plan.primary_count],
                          AHDI_FLAG_EXISTENT, b"XGM",
                          xgm_start, xgm_size)
+
+    # AHDI 3.0 'hd_siz' field: total disk sectors in 4 bytes big-endian.
+    # Optional / informational; modern drivers ignore it but we write
+    # it for byte-level fidelity with real AHDI tooling.
+    buf[AHDI_HD_SIZ_OFFSET:AHDI_HD_SIZ_OFFSET + 4] = (
+        plan.image_sectors).to_bytes(4, "big")
 
     # NOTE: intentionally no 0x55AA signature (this is a pure-AHDI image).
     return bytes(buf)
@@ -362,12 +429,37 @@ def build_root_sector_ppdriver(plan: "ImagePlan") -> bytes:
 
     if plan.has_extended:
         ext_start, ext_size = extended_container_bounds(plan)
+        # PPDRIVER uses LBA-addressable extended (0x0F) to force LBA
+        # semantics on large disks; matches what real PPTOSDOS images
+        # ship with.
         write_mbr_entry(buf, MBR_P0_OFFSET + plan.primary_count * 16,
-                        boot=0x00, part_type=MBR_TYPE_EXTENDED,
+                        boot=0x00, part_type=MBR_TYPE_EXTENDED_LBA,
                         start_lba=ext_start, sector_count=ext_size)
+
+    # PPDRIVER stamps a 4-byte disk signature at MBR offset 0x1B8.
+    # Real PPDRIVER images use a random value; we seed deterministically
+    # from plan inputs so output is byte-stable across runs. HDDRIVER
+    # leaves this field at zero (matched by build_root_sector_hddriver).
+    buf[MBR_DISK_SIGNATURE_OFFSET:MBR_DISK_SIGNATURE_OFFSET + 4] = (
+        _ppdriver_disk_signature(plan))
 
     buf[MBR_SIGNATURE_OFFSET:MBR_SIGNATURE_OFFSET + 2] = MBR_SIGNATURE
     return bytes(buf)
+
+
+def _ppdriver_disk_signature(plan: "ImagePlan") -> bytes:
+    """Deterministic 4-byte disk signature for PPDRIVER images. Same
+    rationale as _fat16_seed_volume_id: same inputs -> same bytes,
+    no wall-clock seeding, no host randomness. Inputs cover the
+    image-shape choices that uniquely identify the plan."""
+    seed = (
+        os.path.basename(os.fspath(plan.image_path)).encode("utf-8",
+                                                              errors="replace")
+        + struct.pack("<II", plan.image_sectors & 0xFFFFFFFF,
+                       len(plan.partitions))
+    )
+    digest = hashlib.sha256(seed).digest()
+    return digest[:4]
 
 
 def build_root_sector_hddriver(plan: "ImagePlan") -> bytes:
@@ -397,8 +489,16 @@ def build_root_sector_hddriver(plan: "ImagePlan") -> bytes:
 
     if plan.has_extended:
         ext_start, ext_size = extended_container_bounds(plan)
+        # HDDRIVER uses CHS-extended FAT16B (0x05) for its container,
+        # not the LBA variant -- matches the byte HDDRIVER itself
+        # writes. NOTE: per the Atari Compendium, HDDRIVER's TOS&DOS
+        # hybrid mode supports only ONE TOS-mountable partition per
+        # drive (the primary in MBR P0; the AHDI overlap at 0x1DE
+        # points only at it). Logical partitions in this EBR chain
+        # are DOS-readable but **not** TOS-mountable; they live for
+        # PC-side use of the same image.
         write_mbr_entry(buf, MBR_P0_OFFSET + 16,
-                        boot=0x00, part_type=MBR_TYPE_EXTENDED,
+                        boot=0x00, part_type=MBR_TYPE_EXTENDED_CHS,
                         start_lba=ext_start, sector_count=ext_size)
 
     # AHDI slot 2 marker (TOS view of the primary partition). Written AFTER
@@ -941,12 +1041,34 @@ class ImagePlan:
 
 def format_max_partition_mb(format_id: str, strict_tos: bool) -> int:
     """Maximum allowed partition size (MB) for a given format and TOS-compat
-    mode, across ALL slots. AHDI honors the TOS BGM cap (256/512); the
-    hybrid formats use the FAT16 ceiling."""
+    mode, across ALL slots.
+
+    AHDI honors the TOS BGM cap (256/512). PPDRIVER / HDDRIVER use the
+    hybrid-layout cap (511 MB) -- bounded by the TOS-side BPB's 16-bit
+    NSECTS field at the max supported TOS bps (8192 on TOS 1.04 - 3.x).
+    The Falcon TOS 4.x ceiling (2 GB) isn't a target here. See the
+    HYBRID_MAX_PARTITION_MB constant for the rationale."""
     if format_id == FORMAT_AHDI:
         return (AHDI_MAX_PARTITION_MB_STRICT if strict_tos
                 else AHDI_MAX_PARTITION_MB)
-    return MAX_PARTITION_MB
+    return HYBRID_MAX_PARTITION_MB
+
+
+def format_min_partition_mb(format_id: str) -> int:
+    """Minimum partition size (MB) for a given format.
+
+    AHDI single-BPB images can host any partition that produces >= 4085
+    FAT16 clusters (around 4-5 MB at native bps); the v1 doesn't enforce
+    a hard min on AHDI -- format_fat16 rejects too-small inputs at
+    write time and the user fixes the size in the dialog.
+
+    Hybrid formats (PPDRIVER / HDDRIVER) require ratio >= 2 in the
+    synthesize step, which the Hatari sector-doubling rule first
+    reaches at ~32 MB. Below that, build_image fails with a cryptic
+    'tos_bps must be a power of two >= 1024'. We catch it earlier."""
+    if format_id == FORMAT_AHDI:
+        return MIN_PARTITION_MB  # 2 MB; format_fat16 rejects below ~4-5 MB
+    return HYBRID_MIN_PARTITION_MB
 
 
 def partition_cap_mb(format_id: str, strict_tos: bool,
@@ -957,14 +1079,138 @@ def partition_cap_mb(format_id: str, strict_tos: bool,
     partition and clamp it to the GEM cap (16 MB strict / 32 MB
     permissive) for legacy-driver compatibility. This is *not* a TOS
     rule per se -- TOS itself only checks the boot flag, and modern
-    drivers boot from BGM up to 512 MB -- but the original AHDI and
+    drivers boot from BGM up to 511 MB -- but the original AHDI and
     early SCSI Tools required the GEM clamp, so we keep it. See
     ahdi_partition_id() for the full rationale. Slots 2..N can be GEM
-    (within the same threshold) or BGM (up to 256/512). Hybrid formats
+    (within the same threshold) or BGM (up to 256/511). Hybrid formats
     have no per-slot distinction."""
     if format_id == FORMAT_AHDI and partition_index == 0:
         return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
     return format_max_partition_mb(format_id, strict_tos)
+
+
+# --------------------------------------------------------------------------
+# Partition-table parsers (used by the TUI's load action and by the test
+# suite). Pure struct.unpack_from; no I/O. The walker + load_image()
+# below add the I/O layer.
+# --------------------------------------------------------------------------
+
+# Tuple form for iteration; the scalar AHDI_SLOT*_OFFSET / MBR_P0_OFFSET
+# constants are still defined above for individual writes.
+AHDI_SLOT_OFFSETS = (AHDI_SLOT0_OFFSET, AHDI_SLOT1_OFFSET,
+                     AHDI_SLOT2_OFFSET, AHDI_SLOT3_OFFSET)
+MBR_SLOT_OFFSETS = tuple(MBR_P0_OFFSET + i * 16 for i in range(4))
+
+
+def parse_ahdi_entry(buf, offset):
+    """Parse a 12-byte AHDI partition entry at `offset` in `buf`.
+
+    Layout (big-endian for the two 32-bit fields):
+        +0   flag        (1 byte; bit 0 = exists, bit 7 = bootable)
+        +1   ident       (3 bytes ASCII; e.g. b"GEM" / b"BGM" / b"XGM")
+        +4   start_lba   (4 bytes, big-endian)
+        +8   size        (4 bytes, big-endian)
+    """
+    start_lba, size_sectors = struct.unpack_from(">II", buf, offset + 4)
+    return {
+        "flag":         buf[offset],
+        "ident":        bytes(buf[offset + 1:offset + 4]),
+        "start_lba":    start_lba,
+        "size_sectors": size_sectors,
+    }
+
+
+def parse_ahdi_root(buf):
+    """Parse the four AHDI slots from a root sector buffer. Empty slots
+    come back with flag=0 / ident=b'\\x00\\x00\\x00'."""
+    return [parse_ahdi_entry(buf, off) for off in AHDI_SLOT_OFFSETS]
+
+
+def parse_mbr_entry(buf, offset):
+    """Parse a 16-byte MBR partition entry at `offset` in `buf`.
+
+    Layout (little-endian for the two 32-bit fields):
+        +0   boot          (1 byte; 0x80 marks active)
+        +1   chs_first     (3 bytes; pack_chs format)
+        +4   part_type     (1 byte; 0x06 = FAT16, 0x0F = extended-LBA)
+        +5   chs_last      (3 bytes)
+        +8   rel_start_lba (4 bytes, little-endian; for EBRs this is
+                            relative to the EBR sector or chain base)
+        +12  sector_count  (4 bytes, little-endian)
+    """
+    rel_start_lba, sector_count = struct.unpack_from("<II", buf, offset + 8)
+    return {
+        "boot":          buf[offset],
+        "chs_first":     bytes(buf[offset + 1:offset + 4]),
+        "part_type":     buf[offset + 4],
+        "chs_last":      bytes(buf[offset + 5:offset + 8]),
+        "rel_start_lba": rel_start_lba,
+        "sector_count":  sector_count,
+    }
+
+
+def parse_mbr_root(buf):
+    """Parse the four MBR slots + the 0x55AA signature. Returns
+    {'slots': [<4 dicts>], 'signature': bytes(2)}."""
+    return {
+        "slots":     [parse_mbr_entry(buf, off) for off in MBR_SLOT_OFFSETS],
+        "signature": bytes(buf[510:512]),
+    }
+
+
+def parse_ebr(buf):
+    """An EBR has the same on-disk layout as an MBR root sector (4 slot
+    positions + signature); only slots 0 and 1 are populated in
+    practice."""
+    return parse_mbr_root(buf)
+
+
+def parse_xgm_descriptor(buf):
+    """Parse an AHDI XGM sub-descriptor: slot 0 = logical partition,
+    slot 1 = next-descriptor link (or empty when chain ends)."""
+    return {
+        "logical": parse_ahdi_entry(buf, AHDI_SLOT_OFFSETS[0]),
+        "link":    parse_ahdi_entry(buf, AHDI_SLOT_OFFSETS[1]),
+    }
+
+
+def parse_bpb(buf, offset):
+    """Parse the BPB / extended boot record at `offset` in a FAT16
+    boot-sector buffer. Returns every documented field as a plain int
+    or bytes value. Multi-byte fields are little-endian."""
+    base = offset
+    return {
+        "jump":                    bytes(buf[base + 0x00:base + 0x03]),
+        "oem":                     bytes(buf[base + 0x03:base + 0x0B]),
+        "bytes_per_sector":        struct.unpack_from(
+                                       "<H", buf, base + 0x0B)[0],
+        "sectors_per_cluster":     buf[base + 0x0D],
+        "reserved_sectors":        struct.unpack_from(
+                                       "<H", buf, base + 0x0E)[0],
+        "num_fats":                buf[base + 0x10],
+        "root_entries":            struct.unpack_from(
+                                       "<H", buf, base + 0x11)[0],
+        "total_sectors_16":        struct.unpack_from(
+                                       "<H", buf, base + 0x13)[0],
+        "media_descriptor":        buf[base + 0x15],
+        "sectors_per_fat_16":      struct.unpack_from(
+                                       "<H", buf, base + 0x16)[0],
+        "sectors_per_track":       struct.unpack_from(
+                                       "<H", buf, base + 0x18)[0],
+        "num_heads":               struct.unpack_from(
+                                       "<H", buf, base + 0x1A)[0],
+        "hidden_sectors":          struct.unpack_from(
+                                       "<I", buf, base + 0x1C)[0],
+        "total_sectors_32":        struct.unpack_from(
+                                       "<I", buf, base + 0x20)[0],
+        "drive_number":            buf[base + 0x24],
+        "extended_boot_signature": buf[base + 0x26],
+        "volume_id":               struct.unpack_from(
+                                       "<I", buf, base + 0x27)[0],
+        "volume_label":            bytes(buf[base + 0x2B:base + 0x36]),
+        "fs_type":                 bytes(buf[base + 0x36:base + 0x3E]),
+        "signature":               bytes(buf[base + 0x1FE:base + 0x200]),
+    }
 
 
 def cap_mb_for_type(format_id: str, strict_tos: bool,
@@ -985,7 +1231,327 @@ def cap_mb_for_type(format_id: str, strict_tos: bool,
         if ident in (b"GEM", "GEM"):
             return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
         return AHDI_MAX_PARTITION_MB_STRICT if strict_tos else AHDI_MAX_PARTITION_MB
-    return MAX_PARTITION_MB
+    return HYBRID_MAX_PARTITION_MB
+
+
+# --------------------------------------------------------------------------
+# Image loader: detect format, walk the partition table, recover labels
+# from each partition's FAT16 BPB. Used by the TUI's L (load) action.
+# --------------------------------------------------------------------------
+
+class ImageLoadError(RuntimeError):
+    """Raised when an image can't be parsed (file too small, no
+    recognisable root sector, corrupt chain, etc.). The TUI surfaces
+    the message verbatim in the status bar."""
+
+
+# PPDRIVER (PPTOSDOS) marker stamped on every partition's BPB by
+# build_image step 3. Per the Atari Compendium it is the canonical
+# detection mark for "this is a PPDRIVER-managed image"; PPDRIVER
+# itself uses it as a distinguishing marker so it can apply the dual-
+# BPB redirection logic.
+PPDRIVER_OEM = b"PPGDODBC"
+
+
+def detect_format(image_path: str):
+    """Return one of "AHDI" / "PPDRIVER" / "HDDRIVER" or None.
+
+    Heuristic (validated against the Atari Compendium notebook):
+      - 0x55AA at byte 510 -> MBR-style root sector. Then:
+          * AHDI overlap at 0x1DE (flag bit 0 set, ident GEM/BGM)
+            -> HDDRIVER's overlap trick.
+          * Else: read the first FAT16 primary's BPB and check for
+            OEM "PPGDODBC" -> PPDRIVER. Without the marker we
+            return None rather than falsely tagging vanilla DOS
+            MBR images as PPDRIVER.
+      - No 0x55AA + at least one valid AHDI slot (GEM/BGM/XGM)
+        -> pure-AHDI image.
+      - Anything else -> None (caller surfaces "format unknown").
+    """
+    with open(image_path, "rb") as f:
+        sec0 = f.read(SECTOR_SIZE)
+    if len(sec0) < SECTOR_SIZE:
+        return None
+    has_mbr_sig = bytes(sec0[510:512]) == MBR_SIGNATURE
+    if has_mbr_sig:
+        # Inspect the bytes at AHDI slot 2 (= MBR slot 2 area). If they
+        # parse as an AHDI partition entry with flag-exists set and a
+        # known ident, this is the HDDRIVER overlap.
+        ahdi_at_slot2 = parse_ahdi_entry(sec0, AHDI_SLOT2_OFFSET)
+        if (ahdi_at_slot2["flag"] & AHDI_FLAG_EXISTENT) and (
+                ahdi_at_slot2["ident"] in (b"GEM", b"BGM")):
+            return FORMAT_HDDRIVER
+        # PPDRIVER: walk MBR slots to find the first FAT16 primary,
+        # then check its BPB OEM. We stamp PPGDODBC on every
+        # partition's BPB at build time, so checking the first one
+        # is sufficient.
+        if _has_ppdriver_oem_marker(image_path, sec0):
+            return FORMAT_PPDRIVER
+        # MBR-signed image without the HDDRIVER overlap and without
+        # the PPDRIVER OEM: not a recognised hybrid (vanilla DOS,
+        # foreign tooling, corrupt root, ...). Return None and let
+        # the caller surface "format unknown".
+        return None
+    # No MBR signature -> pure AHDI if any slot has a valid ident.
+    valid = (b"GEM", b"BGM", b"XGM")
+    for slot in parse_ahdi_root(sec0):
+        if (slot["flag"] & AHDI_FLAG_EXISTENT) and slot["ident"] in valid:
+            return FORMAT_AHDI
+    return None
+
+
+def _has_ppdriver_oem_marker(image_path: str, sec0: bytes) -> bool:
+    """Return True iff the first FAT16 MBR primary's BPB carries the
+    PPDRIVER OEM marker. Conservative on errors (returns False) so a
+    bad read never produces a false-positive classification."""
+    try:
+        mbr = parse_mbr_root(sec0)
+        for slot in mbr["slots"]:
+            if slot["part_type"] != MBR_TYPE_FAT16:
+                continue
+            start_lba = slot["rel_start_lba"]
+            with open(image_path, "rb") as f:
+                f.seek(start_lba * SECTOR_SIZE)
+                bpb_sec = f.read(SECTOR_SIZE)
+            if len(bpb_sec) != SECTOR_SIZE:
+                return False
+            bpb = parse_bpb(bpb_sec, 0)
+            return bpb["oem"] == PPDRIVER_OEM
+        return False
+    except (OSError, struct.error):
+        return False
+
+
+def _read_sector_at(image_path: str, lba: int, image_size: int) -> bytes:
+    """Read one 512-byte sector at `lba`. Raises ImageLoadError when the
+    LBA falls outside the file (defensive against corrupt chain
+    pointers; we never read past the file)."""
+    if lba < 0 or (lba + 1) * SECTOR_SIZE > image_size:
+        raise ImageLoadError(
+            f"chain pointer LBA {lba} is outside the image "
+            f"({image_size} bytes)")
+    with open(image_path, "rb") as f:
+        f.seek(lba * SECTOR_SIZE)
+        buf = f.read(SECTOR_SIZE)
+    if len(buf) != SECTOR_SIZE:
+        raise ImageLoadError(f"short read at LBA {lba}")
+    return buf
+
+
+def _label_from_bpb(image_path: str, start_lba: int,
+                    image_size: int, default: str) -> str:
+    """Read the FAT16 BPB at `start_lba` and return the volume label
+    (uppercased, trimmed). Falls back to `default` if the BPB looks
+    invalid -- we don't fail the whole load for one missing label."""
+    try:
+        sec = _read_sector_at(image_path, start_lba, image_size)
+        bpb = parse_bpb(sec, 0)
+    except (ImageLoadError, struct.error):
+        return default
+    if bpb["signature"] != MBR_SIGNATURE:
+        # Not a recognisable BPB; use default.
+        return default
+    label = bpb["volume_label"].rstrip(b" \x00")
+    try:
+        decoded = label.decode("ascii", errors="replace").strip()
+    except Exception:
+        return default
+    return decoded or default
+
+
+def _load_ahdi(image_path: str, sec0: bytes, image_size: int):
+    """Walk the AHDI root sector and any XGM chain. Returns a list of
+    Partition objects. Raises ImageLoadError on chain corruption."""
+    partitions = []
+    chain_base = None
+    chain_link = None
+
+    for slot_idx, slot in enumerate(parse_ahdi_root(sec0)):
+        if not (slot["flag"] & AHDI_FLAG_EXISTENT):
+            continue
+        if slot["ident"] == b"XGM":
+            chain_base = slot["start_lba"]
+            chain_link = slot["start_lba"]
+            continue
+        if slot["ident"] not in (b"GEM", b"BGM"):
+            continue
+        partitions.append(_partition_from_entry(
+            image_path, image_size, slot, slot_index=len(partitions)))
+
+    # Walk the XGM chain.
+    visited = set()
+    while chain_link is not None:
+        if chain_link in visited:
+            raise ImageLoadError("XGM chain has a cycle")
+        visited.add(chain_link)
+        desc_buf = _read_sector_at(image_path, chain_link, image_size)
+        desc = parse_xgm_descriptor(desc_buf)
+        logical = desc["logical"]
+        if not (logical["flag"] & AHDI_FLAG_EXISTENT):
+            break
+        # Logical partition: start is RELATIVE to the descriptor's LBA.
+        abs_start = chain_link + logical["start_lba"]
+        partitions.append(_partition_from_entry(
+            image_path, image_size,
+            {"flag": logical["flag"], "ident": logical["ident"],
+             "start_lba": abs_start,
+             "size_sectors": logical["size_sectors"]},
+            slot_index=len(partitions)))
+        link = desc["link"]
+        if not (link["flag"] & AHDI_FLAG_EXISTENT):
+            break
+        chain_link = chain_base + link["start_lba"]
+
+    return partitions
+
+
+def _load_mbr(image_path: str, sec0: bytes, image_size: int,
+              skip_slot2: bool):
+    """Walk an MBR root sector and any EBR chain. `skip_slot2` skips
+    the slot-2 entry (used for HDDRIVER, where 0x1DE holds an AHDI
+    overlap rather than a real MBR partition)."""
+    partitions = []
+    ext_base = None
+    ext_link = None
+
+    mbr = parse_mbr_root(sec0)
+    for i, slot in enumerate(mbr["slots"]):
+        if skip_slot2 and i == 2:
+            continue
+        ptype = slot["part_type"]
+        if ptype == 0:
+            continue
+        if ptype in MBR_EXTENDED_TYPES:
+            # Either 0x0F (PPDRIVER LBA) or 0x05 (HDDRIVER CHS) is a
+            # valid extended-container marker -- accept both.
+            ext_base = slot["rel_start_lba"]
+            ext_link = slot["rel_start_lba"]
+            continue
+        if ptype != MBR_TYPE_FAT16:
+            # Unknown partition type; skip.
+            continue
+        partitions.append(_partition_from_mbr(
+            image_path, image_size,
+            start_lba=slot["rel_start_lba"],
+            size_sectors=slot["sector_count"],
+            slot_index=len(partitions)))
+
+    # Walk EBR chain.
+    visited = set()
+    while ext_link is not None:
+        if ext_link in visited:
+            raise ImageLoadError("EBR chain has a cycle")
+        visited.add(ext_link)
+        ebr_buf = _read_sector_at(image_path, ext_link, image_size)
+        ebr = parse_ebr(ebr_buf)
+        slot0 = ebr["slots"][0]
+        if slot0["part_type"] == 0:
+            break
+        abs_start = ext_link + slot0["rel_start_lba"]
+        partitions.append(_partition_from_mbr(
+            image_path, image_size,
+            start_lba=abs_start,
+            size_sectors=slot0["sector_count"],
+            slot_index=len(partitions)))
+        slot1 = ebr["slots"][1]
+        if slot1["part_type"] not in MBR_EXTENDED_TYPES:
+            break
+        ext_link = ext_base + slot1["rel_start_lba"]
+
+    return partitions
+
+
+def _partition_from_entry(image_path: str, image_size: int, entry: dict,
+                          slot_index: int) -> "Partition":
+    """Build a Partition from an AHDI-table entry, recovering the label
+    from the FAT16 BPB at start_lba. AHDI partitions live at bps =
+    Hatari-doubling-rule(size_sectors); we use that convention to
+    locate the BPB."""
+    size_sec = entry["size_sectors"]
+    size_mb = (size_sec * SECTOR_SIZE) // MIB
+    default = f"P{slot_index + 1}"
+    name = _label_from_bpb(image_path, entry["start_lba"], image_size,
+                            default=default)
+    p = Partition(name=name, size_mb=size_mb,
+                   size_sectors=size_sec,
+                   start_lba=entry["start_lba"])
+    ident = entry["ident"]
+    p.ahdi_ident = (ident.decode("ascii", errors="replace")
+                    if isinstance(ident, (bytes, bytearray)) else ident)
+    return p
+
+
+def _partition_from_mbr(image_path: str, image_size: int,
+                        start_lba: int, size_sectors: int,
+                        slot_index: int) -> "Partition":
+    """Build a Partition from an MBR/EBR FAT16 entry. The DOS BPB lives
+    at start_lba (bps=512 for the dual-BPB DOS view)."""
+    size_mb = (size_sectors * SECTOR_SIZE) // MIB
+    default = f"P{slot_index + 1}"
+    name = _label_from_bpb(image_path, start_lba, image_size,
+                            default=default)
+    p = Partition(name=name, size_mb=size_mb,
+                   size_sectors=size_sectors, start_lba=start_lba)
+    return p
+
+
+def _infer_strict_tos(partitions) -> bool:
+    """Best-effort guess at strict_tos from partition sizes. Strict if
+    slot 0 <= 16 MB and all later partitions <= 256 MB. Only meaningful
+    for AHDI; the caller should still set strict_tos=False on hybrid
+    formats."""
+    for i, p in enumerate(partitions):
+        cap = AHDI_GEM_MAX_MB_STRICT if i == 0 else AHDI_MAX_PARTITION_MB_STRICT
+        if p.size_mb > cap:
+            return False
+    return True
+
+
+def load_image(image_path: str) -> dict:
+    """Parse an existing image and return a planning summary:
+        {
+          "format_id": "AHDI" / "PPDRIVER" / "HDDRIVER",
+          "strict_tos": bool,         # AHDI-only inference
+          "partitions": list[Partition],
+          "strict_tos_inferred": bool, # True iff we guessed
+        }
+    Raises ImageLoadError on unrecognised or corrupt images."""
+    try:
+        image_size = os.path.getsize(image_path)
+    except OSError as e:
+        raise ImageLoadError(f"cannot stat image: {e}") from e
+    if image_size < SECTOR_SIZE:
+        raise ImageLoadError(
+            f"image too small ({image_size} bytes); need at least 512")
+
+    fmt = detect_format(image_path)
+    if fmt is None:
+        raise ImageLoadError(
+            "no recognisable AHDI or MBR partition table at sector 0")
+
+    sec0 = _read_sector_at(image_path, 0, image_size)
+    if fmt == FORMAT_AHDI:
+        partitions = _load_ahdi(image_path, sec0, image_size)
+    elif fmt == FORMAT_HDDRIVER:
+        partitions = _load_mbr(image_path, sec0, image_size,
+                                skip_slot2=True)
+    else:
+        partitions = _load_mbr(image_path, sec0, image_size,
+                                skip_slot2=False)
+
+    if not partitions:
+        raise ImageLoadError(
+            f"recognised {fmt} root sector but no partitions found")
+
+    strict_inferred = (fmt == FORMAT_AHDI)
+    strict_tos = _infer_strict_tos(partitions) if strict_inferred else False
+
+    return {
+        "format_id": fmt,
+        "strict_tos": strict_tos,
+        "strict_tos_inferred": strict_inferred,
+        "partitions": partitions,
+    }
 
 
 def first_partition_start_lba(format_id: str) -> int:
@@ -1180,7 +1746,7 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
     # treated as the boot partition and clamped to the GEM cap (16/32
     # MB) for legacy-driver compatibility -- not a hard TOS rule but a
     # defensive default; see ahdi_partition_id() for the rationale.
-    # Slots 2..N follow the BGM 256/512 MB cap. Hybrid formats have no
+    # Slots 2..N follow the BGM 256/511 MB cap. Hybrid formats have no
     # per-slot distinction.
     if format_id == FORMAT_AHDI:
         mode_label = "TOS < 1.04" if strict_tos else "TOS 1.04+"
@@ -1192,6 +1758,30 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
                     f"partition {part.name!r} is {part.size_mb} MB but "
                     f"the {mode_label} {kind} cap at slot {i + 1} is "
                     f"{cap_mb} MB; lower the size or disable strict mode")
+    else:
+        # Hybrid formats (PPDRIVER / HDDRIVER) have a hard min size:
+        # the synthesize step requires tos_bps >= 1024, which the
+        # Hatari sector-doubling rule first reaches at ~32 MB. Catch
+        # it here with a clear message instead of letting the user
+        # hit the cryptic 'tos_bps must be a power of two >= 1024'
+        # later. The hybrid max (511 MB) is enforced via
+        # cap_mb_for_type() at the TUI layer; we don't repeat it
+        # here because the planner accepts any size up to the FAT16
+        # cluster cap and the synthesize layer rejects whatever is
+        # actually unbuildable.
+        for i, part in enumerate(partitions):
+            if part.size_mb < HYBRID_MIN_PARTITION_MB:
+                raise ValueError(
+                    f"partition {part.name!r} is {part.size_mb} MB but "
+                    f"{format_id} requires >= {HYBRID_MIN_PARTITION_MB} "
+                    f"MB per partition (hybrid layout requires logical "
+                    f"sector size >= 1024)")
+            if part.size_mb > HYBRID_MAX_PARTITION_MB:
+                raise ValueError(
+                    f"partition {part.name!r} is {part.size_mb} MB but "
+                    f"{format_id} caps at {HYBRID_MAX_PARTITION_MB} MB "
+                    f"per partition (TOS NSECTS 16-bit limit at "
+                    f"bps=8192)")
 
     # Decide the MBR primary vs. extended-chain split. Partitions with index
     # < primary_count land directly in MBR slots; partitions at index >=
@@ -1252,10 +1842,10 @@ def ahdi_partition_id(partition_mb: int, strict_tos: bool = False,
     *defensive compatibility* choice rather than a hard TOS requirement:
     TOS itself only checks the boot flag (bit 7 of the partition-entry
     flag byte), not the ident; modern drivers (HDDRIVER, PPDRIVER, ICD
-    Pro) happily boot from BGM up to 512 MB. But the original AHDI and
+    Pro) happily boot from BGM up to 511 MB. But the original AHDI and
     early SCSI Tools required ident == GEM and size <= 16 MB on the
     boot slot, so emitting GEM at slot 0 is the broadest-compatibility
-    pick. Removing this clamp would let the user set up a 512 MB BGM
+    pick. Removing this clamp would let the user set up a 511 MB BGM
     boot partition that works on modern drivers but fails on legacy
     ones; revisit if a workflow actually wants that.
 
@@ -1392,6 +1982,12 @@ def build_image(plan: ImagePlan, progress=None) -> None:
                     next_chain_size=next_chain_size,
                 )
             else:
+                # PPDRIVER uses 0x0F (LBA), HDDRIVER uses 0x05 (CHS)
+                # for the next-EBR-link type byte. Match the
+                # container type emitted in the root sector.
+                ext_type = (MBR_TYPE_EXTENDED_CHS
+                            if plan.format_id == FORMAT_HDDRIVER
+                            else MBR_TYPE_EXTENDED_LBA)
                 desc = build_ebr_sector(
                     logical_abs_start=part.start_lba,
                     logical_size=part.size_sectors,
@@ -1399,6 +1995,7 @@ def build_image(plan: ImagePlan, progress=None) -> None:
                     ext_base_abs_lba=chain_base,
                     next_ebr_abs_lba=next_desc_abs,
                     next_chain_size=next_chain_size,
+                    extended_type=ext_type,
                 )
             write_sector(plan.image_path, part.ebr_lba, desc)
 
@@ -1469,7 +2066,7 @@ def ask_tos_compat() -> bool:
     print("TOS < 1.04 was the original TOS shipped with early machines")
     print("(520ST, 1040ST, Mega ST). It caps AHDI partitions tighter:")
     print("   - GEM <= 16 MB   (vs 32 MB on TOS 1.04+)")
-    print("   - BGM <= 256 MB  (vs 512 MB on TOS 1.04+)")
+    print("   - BGM <= 256 MB  (vs 511 MB on TOS 1.04+)")
     return ask_yes_no(
         "Force compatibility with TOS < 1.04 "
         "(original 520ST / 1040ST / Mega ST)?",

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -172,7 +172,7 @@ SECTOR_SIZE_WARN_THRESHOLD = 8192
 # which is the ceiling for every format once the extended chain is in play.
 MAX_PARTITIONS = {
     FORMAT_AHDI: 14,       # up to 4 primary, rest via XGM chain
-    FORMAT_PPDRIVER: 14,   # 1 primary + rest via MBR extended chain
+    FORMAT_PPDRIVER: 14,   # up to 4 primary, rest via MBR extended chain
     FORMAT_HDDRIVER: 14,   # 1 primary max, rest via MBR extended chain
 }
 
@@ -183,7 +183,8 @@ MAX_PARTITIONS = {
 # remaining partitions live as logicals inside that chain.
 MAX_PRIMARY_PARTITIONS = {
     FORMAT_AHDI: 4,        # 4 AHDI root slots; slot 3 becomes XGM when N>4
-    FORMAT_PPDRIVER: 1,    # PPTOSDOS convention: one primary + extended chain
+    FORMAT_PPDRIVER: 4,    # full MBR primary use (each primary <= 255 MB);
+                           # extended chain kicks in at N >= 5
     FORMAT_HDDRIVER: 1,    # HDDRIVER convention: one primary + AHDI marker
 }
 
@@ -1046,11 +1047,28 @@ def copy_file_into_image(src_path: str, dst_path: str,
 class Partition:
     name: str
     size_mb: int
+    # User-controlled (or load_image-derived) layout role:
+    is_extended: bool = False       # False = MBR/AHDI primary slot;
+                                    # True  = lives in the extended/XGM
+                                    #         chain. Slot 0 must be False.
+                                    # On hybrid formats the cap follows
+                                    # this flag: primary <= 255 MB
+                                    # (bps<=4096); extended <= 511 MB
+                                    # (bps<=8192). HDDRIVER allows at
+                                    # most one primary; PPDRIVER allows
+                                    # up to four. AHDI keeps GEM/BGM
+                                    # caps for primaries; XGM logicals
+                                    # follow BGM caps.
+
     # Derived during planning:
     size_sectors: int = 0           # 512-byte physical sectors
     start_lba: int = 0              # in 512-byte physical sectors
     ebr_lba: int = 0                # 0 = primary; otherwise LBA of this
                                     # partition's Extended Boot Record
+                                    # (set by plan_image / load_image;
+                                    # is_extended is the user-side
+                                    # source of truth, ebr_lba is its
+                                    # on-disk projection).
 
     # FAT16 BPB parameters for the DOS-side filesystem:
     dos_bps: int = 512              # bytesPerSec in DOS BPB
@@ -1111,7 +1129,8 @@ def format_min_partition_mb(format_id: str) -> int:
 
 
 def partition_cap_mb(format_id: str, strict_tos: bool,
-                     partition_index: int) -> int:
+                     partition_index: int,
+                     primary_count: int = 1) -> int:
     """Per-slot partition-size cap.
 
     On AHDI we conservatively treat the first partition as the boot
@@ -1134,7 +1153,8 @@ def partition_cap_mb(format_id: str, strict_tos: bool,
     rationale in the constants block."""
     if format_id == FORMAT_AHDI and partition_index == 0:
         return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
-    if format_id in (FORMAT_PPDRIVER, FORMAT_HDDRIVER) and partition_index == 0:
+    if (format_id in (FORMAT_PPDRIVER, FORMAT_HDDRIVER)
+            and partition_index < primary_count):
         return HYBRID_PRIMARY_MAX_MB
     return format_max_partition_mb(format_id, strict_tos)
 
@@ -1264,7 +1284,8 @@ def parse_bpb(buf, offset):
 
 
 def cap_mb_for_type(format_id: str, strict_tos: bool,
-                    ident, slot_index: Optional[int] = None) -> int:
+                    ident, slot_index: Optional[int] = None,
+                    primary_count: int = 1) -> int:
     """Cap (MB) for a partition given its on-disk type ident.
 
     Used by interactive callers (the TUI dialog) where the user picks
@@ -1274,18 +1295,19 @@ def cap_mb_for_type(format_id: str, strict_tos: bool,
     AHDI: ident b"GEM" / "GEM" -> GEM cap; b"BGM" / "BGM" -> BGM cap;
           unknown -> BGM cap (the more permissive default).
     Hybrid formats (PPDRIVER / HDDRIVER): ident is ignored. When
-          slot_index is 0, the hybrid PRIMARY cap (255 MB) applies --
-          real PPDRIVER and real HDDRIVER on Atari hardware fail to
-          read primary partitions whose TOS BPB carries bps>4096.
-          Slot >= 1 (or unspecified) returns the FAT16 ceiling
-          (HYBRID_MAX_PARTITION_MB, 511 MB). See
+          slot_index < primary_count, the hybrid PRIMARY cap (255 MB)
+          applies -- real PPDRIVER and real HDDRIVER on Atari hardware
+          fail to read primary partitions whose TOS BPB carries
+          bps>4096. PPDRIVER allows up to 4 primaries; HDDRIVER stays
+          at 1. Logical slots (slot >= primary_count, or slot_index
+          unspecified) return HYBRID_MAX_PARTITION_MB (511 MB). See
           HYBRID_PRIMARY_MAX_MB rationale in the constants block.
     """
     if format_id == FORMAT_AHDI:
         if ident in (b"GEM", "GEM"):
             return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
         return AHDI_MAX_PARTITION_MB_STRICT if strict_tos else AHDI_MAX_PARTITION_MB
-    if slot_index == 0:
+    if slot_index is not None and slot_index < primary_count:
         return HYBRID_PRIMARY_MAX_MB
     return HYBRID_MAX_PARTITION_MB
 
@@ -1554,7 +1576,8 @@ def _partition_from_entry(image_path: str, image_size: int, entry: dict,
     p = Partition(name=name, size_mb=size_mb,
                    size_sectors=size_sec,
                    start_lba=entry["start_lba"],
-                   ebr_lba=ebr_lba)
+                   ebr_lba=ebr_lba,
+                   is_extended=(ebr_lba != 0))
     ident = entry["ident"]
     p.ahdi_ident = (ident.decode("ascii", errors="replace")
                     if isinstance(ident, (bytes, bytearray)) else ident)
@@ -1579,7 +1602,8 @@ def _partition_from_mbr(image_path: str, image_size: int,
                             default=default)
     p = Partition(name=name, size_mb=size_mb,
                    size_sectors=size_sectors, start_lba=start_lba,
-                   ebr_lba=ebr_lba)
+                   ebr_lba=ebr_lba,
+                   is_extended=(ebr_lba != 0))
     return p
 
 
@@ -1717,15 +1741,19 @@ def partition_layout(format_id: str, n: int) -> dict:
     extended chain.
 
     - AHDI: up to 4 primary (AHDI-table slots); no extended support in v1.
-    - PPDRIVER: ONE primary + the rest in an MBR extended container.
-      Matches the documented PPTOSDOS convention. Hardware testing
-      confirmed multi-primary PPDRIVER images at >256 MB partition
-      sizes fail to read parts of the filesystem on real Atari
-      hardware (validated against the Compendium notebook); the
-      single-primary layout is what real PPDRIVER setup tools
-      produce.
-    - HDDRIVER: one primary plus an extended container. Matches the
-      real-world HDDRIVER TOS&DOS hybrid layout.
+    - PPDRIVER: up to 4 primary, plus an MBR extended container when
+      N > 4 (3 primary + N-3 logical). Multi-primary is the documented
+      PPTOSDOS convention; the Compendium calls out examples of real
+      tooling producing 300 MB+ primaries in MBR slots beyond 0. The
+      hardware-verified constraint is per-PRIMARY: each primary's TOS
+      bps must stay <= 4096, i.e. each primary <= HYBRID_PRIMARY_MAX_MB
+      (255 MB). The earlier "single-primary" iteration of this rule
+      was based on a misdiagnosis of a 2 x 511 MB failure that turned
+      out to be the bps>4096-in-primary issue, not multi-primary
+      itself.
+    - HDDRIVER: one primary plus an extended container. The hybrid
+      AHDI overlap consumes MBR slot 2 (the 0x1DE trick), and real
+      HDDRIVER setup tools always produce single-primary layouts.
 
     Returns {'primary_count', 'has_extended', 'logical_count'}.
     """
@@ -1746,15 +1774,19 @@ def partition_layout(format_id: str, n: int) -> dict:
                 "logical_count": n - primary}
 
     if format_id == FORMAT_PPDRIVER:
-        # PPTOSDOS convention: one primary slot, every other partition
-        # in the LBA-extended chain (MBR type 0x0F). Using multiple
-        # primaries breaks real Atari hardware reads at >256 MB
-        # partition sizes (verified empirically; see partition_layout
-        # docstring).
-        primary = MAX_PRIMARY_PARTITIONS[FORMAT_PPDRIVER]   # always 1
-        if n == primary:
-            return {"primary_count": primary, "has_extended": False,
+        # PPDRIVER allows up to MAX_PRIMARY_PARTITIONS (4) primary
+        # slots. Each primary is independently capped at
+        # HYBRID_PRIMARY_MAX_MB (255 MB) -- bps>4096 in any primary
+        # is what real-hardware testing showed breaks; the original
+        # multi-primary failure was specifically two 511 MB primaries
+        # at bps=8192. With the per-slot 255 MB cap landed, multi-
+        # primary is back to working as PPTOSDOS originally intended.
+        # When N > 4, fall back to (cap-1) primaries plus an MBR
+        # extended container (3 primary + N-3 logical, up to 14 total).
+        if n <= MAX_PRIMARY_PARTITIONS[FORMAT_PPDRIVER]:
+            return {"primary_count": n, "has_extended": False,
                     "logical_count": 0}
+        primary = MAX_PRIMARY_PARTITIONS[FORMAT_PPDRIVER] - 1
         return {"primary_count": primary, "has_extended": True,
                 "logical_count": n - primary}
 
@@ -1908,18 +1940,46 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
                     f"the {mode_label} {kind} cap at slot {i + 1} is "
                     f"{cap_mb} MB; lower the size or disable strict mode")
     else:
-        # Hybrid formats (PPDRIVER / HDDRIVER):
-        # - Per-partition floor HYBRID_MIN_PARTITION_MB (32 MB), so
-        #   the synthesize step's tos_bps >= 1024 invariant holds.
-        # - Per-partition ceiling HYBRID_MAX_PARTITION_MB (511 MB),
-        #   the TOS NSECTS unsigned-16 ceiling at bps=8192.
-        # - Slot 0 (the single primary) tightens further to
-        #   HYBRID_PRIMARY_MAX_MB (255 MB): real-hardware testing
-        #   shows primaries with bps>4096 don't read correctly, and
-        #   the doubling rule jumps to bps=8192 above 255 MB. The
-        #   workaround for users who want a bigger total partition is
-        #   to add a small primary and put the bulk in the extended
-        #   chain, which is what real PPDRIVER setup tools produce.
+        # Hybrid formats (PPDRIVER / HDDRIVER) follow per-partition
+        # rules driven by Partition.is_extended (set by the user via
+        # the TUI dialog or carried over from load_image):
+        #
+        #   * Slot 0 must be a primary (is_extended=False). The first
+        #     partition is the boot/primary slot and is required by
+        #     both drivers.
+        #   * Once a partition has is_extended=True, all subsequent
+        #     partitions must also be extended (no primary may follow
+        #     a logical -- standard MBR convention; the extended
+        #     chain is contiguous after the primary block).
+        #   * PPDRIVER allows up to MAX_PRIMARY_PARTITIONS=4 primaries;
+        #     HDDRIVER allows exactly 1.
+        #   * Per-partition floor HYBRID_MIN_PARTITION_MB (32 MB).
+        #   * Primary cap HYBRID_PRIMARY_MAX_MB (255 MB; bps<=4096).
+        #   * Extended cap HYBRID_MAX_PARTITION_MB (511 MB; bps<=8192).
+        if partitions[0].is_extended:
+            raise ValueError(
+                f"first partition must be a primary; "
+                f"{format_id} requires the first slot to be a primary "
+                f"(boot) partition")
+        primary_count = 0
+        seen_extended = False
+        for i, part in enumerate(partitions):
+            if part.is_extended:
+                seen_extended = True
+            else:
+                if seen_extended:
+                    raise ValueError(
+                        f"partition {part.name!r} at slot {i} is a "
+                        f"primary but follows an extended partition; "
+                        f"primaries must come before any extended "
+                        f"partitions (single contiguous primary block)")
+                primary_count += 1
+        max_primaries = MAX_PRIMARY_PARTITIONS[format_id]
+        if primary_count > max_primaries:
+            raise ValueError(
+                f"{format_id} allows at most {max_primaries} primary "
+                f"partition(s); plan has {primary_count}. Mark the "
+                f"surplus partition(s) as extended.")
         for i, part in enumerate(partitions):
             if part.size_mb < HYBRID_MIN_PARTITION_MB:
                 raise ValueError(
@@ -1927,33 +1987,44 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
                     f"{format_id} requires >= {HYBRID_MIN_PARTITION_MB} "
                     f"MB per partition (hybrid layout requires logical "
                     f"sector size >= 1024)")
-            cap_mb = partition_cap_mb(format_id, strict_tos, i)
+            if part.is_extended:
+                cap_mb = HYBRID_MAX_PARTITION_MB
+                kind = "extended"
+            else:
+                cap_mb = HYBRID_PRIMARY_MAX_MB
+                kind = "primary slot (bps must stay <= 4096)"
             if part.size_mb > cap_mb:
-                kind = ("primary slot (bps must stay <= 4096)" if i == 0
-                        else "logical")
                 raise ValueError(
                     f"partition {part.name!r} is {part.size_mb} MB but "
                     f"{format_id} {kind} cap is {cap_mb} MB; lower the "
-                    f"size or move it into the extended chain")
-            if part.size_mb > HYBRID_MAX_PARTITION_MB:
-                raise ValueError(
-                    f"partition {part.name!r} is {part.size_mb} MB but "
-                    f"{format_id} caps at {HYBRID_MAX_PARTITION_MB} MB "
-                    f"per partition (TOS NSECTS 16-bit limit at "
-                    f"bps=8192)")
+                    f"size or change its kind")
 
-    # Decide the MBR primary vs. extended-chain split. Partitions with index
-    # < primary_count land directly in MBR slots; partitions at index >=
-    # primary_count become logicals in an MBR extended container and each
-    # gets a 1-sector EBR sector placed immediately in front of it.
-    layout = partition_layout(format_id, len(partitions))
-    plan.primary_count = layout["primary_count"]
-    plan.has_extended = layout["has_extended"]
+    # Decide the MBR primary vs. extended-chain split.
+    #
+    # On hybrid formats (PPDRIVER / HDDRIVER), the user controls this
+    # per-partition via Partition.is_extended; we trust the flag here
+    # (validation above already enforced "primaries are contiguous and
+    # come first" so primary_count = leading partitions with
+    # is_extended=False).
+    #
+    # On AHDI we derive the layout from the partition count -- AHDI
+    # has no user-facing primary/extended toggle yet; the XGM chain
+    # kicks in automatically when N > 4 (slot 3 becomes the chain
+    # head). We back-fill Partition.is_extended for AHDI so the EBR-
+    # assignment loop below can trust the flag uniformly.
+    if format_id == FORMAT_AHDI:
+        layout = partition_layout(format_id, len(partitions))
+        plan.primary_count = layout["primary_count"]
+        plan.has_extended = layout["has_extended"]
+        for i, part in enumerate(partitions):
+            part.is_extended = (i >= plan.primary_count)
+    else:
+        plan.primary_count = sum(1 for p in partitions if not p.is_extended)
+        plan.has_extended = any(p.is_extended for p in partitions)
 
     next_lba = first_partition_start_lba(format_id)
-    for i, part in enumerate(partitions):
-        is_logical = i >= plan.primary_count
-        if is_logical:
+    for part in partitions:
+        if part.is_extended:
             part.ebr_lba = next_lba
             next_lba += 1
         else:

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -96,6 +96,25 @@ AHDI_GEM_MAX_MB = 31                 # TOS 1.04+ GEM cap (was 32; off by one)
 HYBRID_MAX_PARTITION_MB = 511
 HYBRID_MIN_PARTITION_MB = 32
 
+# Hybrid (PPDRIVER / HDDRIVER) PRIMARY-slot cap. Empirical real-world
+# constraint: real PPDRIVER and real HDDRIVER on Atari hardware fail
+# to read primary partitions whose TOS BPB carries bps>4096. Logicals
+# in the extended chain are unaffected (real reference images put
+# 480 MB FAT16 logicals at bps=8192 and they work). The cause is
+# inside the driver / IPL boot path, not in TOS itself.
+#
+# The math: choose_logical_sector_size keeps bps=4096 only while
+# clusters_at_spc=2 <= 32765, i.e. sec_512 <= 524240, i.e. partition
+# size <= 255 MB. At 256 MB exactly the doubling rule jumps to
+# bps=8192, which is invalid for the primary slot.
+#
+# Derived from a side-by-side TOS-BPB comparison of a real PPDRIVER
+# 1 GB raw dump (sole primary at 232 MB, bps=4096; 480 MB logical at
+# bps=8192) against a 511 MB primary built by this tool that failed
+# to read on real hardware. The same constraint applies to HDDRIVER
+# (same hybrid TOS+DOS BPB structure; same driver class).
+HYBRID_PRIMARY_MAX_MB = 255
+
 # mkfs behavior: sectors per cluster fixed at 2 (matches Hatari's script and
 # real HDDRIVER/PPDRIVER images we've seen on disk).
 SECTORS_PER_CLUSTER = 2
@@ -1105,9 +1124,18 @@ def partition_cap_mb(format_id: str, strict_tos: bool,
     correct) -- ident strictly follows bps in ahdi_partition_id(),
     so a slot-0 partition above this cap would mismatch its BPB.
     Slots 2..N can be GEM (within the same cap) or BGM (up to
-    256/511). Hybrid formats have no per-slot distinction."""
+    256/511).
+
+    Hybrid (PPDRIVER / HDDRIVER): the primary slot is capped at
+    HYBRID_PRIMARY_MAX_MB (255 MB). Real PPDRIVER and real HDDRIVER
+    on Atari hardware fail to read primary partitions whose TOS BPB
+    carries bps>4096; logicals in the extended chain are unaffected
+    and use the full HYBRID_MAX cap. See HYBRID_PRIMARY_MAX_MB
+    rationale in the constants block."""
     if format_id == FORMAT_AHDI and partition_index == 0:
         return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
+    if format_id in (FORMAT_PPDRIVER, FORMAT_HDDRIVER) and partition_index == 0:
+        return HYBRID_PRIMARY_MAX_MB
     return format_max_partition_mb(format_id, strict_tos)
 
 
@@ -1236,7 +1264,7 @@ def parse_bpb(buf, offset):
 
 
 def cap_mb_for_type(format_id: str, strict_tos: bool,
-                    ident) -> int:
+                    ident, slot_index: Optional[int] = None) -> int:
     """Cap (MB) for a partition given its on-disk type ident.
 
     Used by interactive callers (the TUI dialog) where the user picks
@@ -1245,14 +1273,20 @@ def cap_mb_for_type(format_id: str, strict_tos: bool,
 
     AHDI: ident b"GEM" / "GEM" -> GEM cap; b"BGM" / "BGM" -> BGM cap;
           unknown -> BGM cap (the more permissive default).
-    Hybrid formats (PPDRIVER / HDDRIVER): ident is ignored, returns
-          the FAT16 ceiling. The DOS view doesn't honor the TOS BGM
-          rules.
+    Hybrid formats (PPDRIVER / HDDRIVER): ident is ignored. When
+          slot_index is 0, the hybrid PRIMARY cap (255 MB) applies --
+          real PPDRIVER and real HDDRIVER on Atari hardware fail to
+          read primary partitions whose TOS BPB carries bps>4096.
+          Slot >= 1 (or unspecified) returns the FAT16 ceiling
+          (HYBRID_MAX_PARTITION_MB, 511 MB). See
+          HYBRID_PRIMARY_MAX_MB rationale in the constants block.
     """
     if format_id == FORMAT_AHDI:
         if ident in (b"GEM", "GEM"):
             return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
         return AHDI_MAX_PARTITION_MB_STRICT if strict_tos else AHDI_MAX_PARTITION_MB
+    if slot_index == 0:
+        return HYBRID_PRIMARY_MAX_MB
     return HYBRID_MAX_PARTITION_MB
 
 
@@ -1856,16 +1890,18 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
                     f"the {mode_label} {kind} cap at slot {i + 1} is "
                     f"{cap_mb} MB; lower the size or disable strict mode")
     else:
-        # Hybrid formats (PPDRIVER / HDDRIVER) have a hard min size:
-        # the synthesize step requires tos_bps >= 1024, which the
-        # Hatari sector-doubling rule first reaches at ~32 MB. Catch
-        # it here with a clear message instead of letting the user
-        # hit the cryptic 'tos_bps must be a power of two >= 1024'
-        # later. The hybrid max (511 MB) is enforced via
-        # cap_mb_for_type() at the TUI layer; we don't repeat it
-        # here because the planner accepts any size up to the FAT16
-        # cluster cap and the synthesize layer rejects whatever is
-        # actually unbuildable.
+        # Hybrid formats (PPDRIVER / HDDRIVER):
+        # - Per-partition floor HYBRID_MIN_PARTITION_MB (32 MB), so
+        #   the synthesize step's tos_bps >= 1024 invariant holds.
+        # - Per-partition ceiling HYBRID_MAX_PARTITION_MB (511 MB),
+        #   the TOS NSECTS unsigned-16 ceiling at bps=8192.
+        # - Slot 0 (the single primary) tightens further to
+        #   HYBRID_PRIMARY_MAX_MB (255 MB): real-hardware testing
+        #   shows primaries with bps>4096 don't read correctly, and
+        #   the doubling rule jumps to bps=8192 above 255 MB. The
+        #   workaround for users who want a bigger total partition is
+        #   to add a small primary and put the bulk in the extended
+        #   chain, which is what real PPDRIVER setup tools produce.
         for i, part in enumerate(partitions):
             if part.size_mb < HYBRID_MIN_PARTITION_MB:
                 raise ValueError(
@@ -1873,6 +1909,14 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
                     f"{format_id} requires >= {HYBRID_MIN_PARTITION_MB} "
                     f"MB per partition (hybrid layout requires logical "
                     f"sector size >= 1024)")
+            cap_mb = partition_cap_mb(format_id, strict_tos, i)
+            if part.size_mb > cap_mb:
+                kind = ("primary slot (bps must stay <= 4096)" if i == 0
+                        else "logical")
+                raise ValueError(
+                    f"partition {part.name!r} is {part.size_mb} MB but "
+                    f"{format_id} {kind} cap is {cap_mb} MB; lower the "
+                    f"size or move it into the extended chain")
             if part.size_mb > HYBRID_MAX_PARTITION_MB:
                 raise ValueError(
                     f"partition {part.name!r} is {part.size_mb} MB but "

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -2082,12 +2082,13 @@ def build_image(plan: ImagePlan, progress=None) -> None:
                     next_chain_size=next_chain_size,
                 )
             else:
-                # PPDRIVER uses 0x0F (LBA), HDDRIVER uses 0x05 (CHS)
-                # for the next-EBR-link type byte. Match the
-                # container type emitted in the root sector.
-                ext_type = (MBR_TYPE_EXTENDED_CHS
-                            if plan.format_id == FORMAT_HDDRIVER
-                            else MBR_TYPE_EXTENDED_LBA)
+                # Real PPDRIVER and HDDRIVER images both use 0x05
+                # (CHS-extended) for the next-EBR-link byte inside
+                # an EBR, even when the OUTER container at MBR slot 1
+                # is 0x0F (LBA-extended). Verified against a real
+                # PPDRIVER 1 GB raw dump: outer = 0x0F, chain links
+                # = 0x05 throughout. Standard DOS convention.
+                ext_type = MBR_TYPE_EXTENDED_CHS
                 desc = build_ebr_sector(
                     logical_abs_start=part.start_lba,
                     logical_size=part.size_sectors,

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -946,6 +946,27 @@ def partition_cap_mb(format_id: str, strict_tos: bool,
     return format_max_partition_mb(format_id, strict_tos)
 
 
+def cap_mb_for_type(format_id: str, strict_tos: bool,
+                    ident) -> int:
+    """Cap (MB) for a partition given its on-disk type ident.
+
+    Used by interactive callers (the TUI dialog) where the user picks
+    the type explicitly and we need the cap for *that* type, not the
+    auto-pick that partition_cap_mb() implies from the slot index.
+
+    AHDI: ident b"GEM" / "GEM" -> GEM cap; b"BGM" / "BGM" -> BGM cap;
+          unknown -> BGM cap (the more permissive default).
+    Hybrid formats (PPDRIVER / HDDRIVER): ident is ignored, returns
+          the FAT16 ceiling. The DOS view doesn't honor the TOS BGM
+          rules.
+    """
+    if format_id == FORMAT_AHDI:
+        if ident in (b"GEM", "GEM"):
+            return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
+        return AHDI_MAX_PARTITION_MB_STRICT if strict_tos else AHDI_MAX_PARTITION_MB
+    return MAX_PARTITION_MB
+
+
 def first_partition_start_lba(format_id: str) -> int:
     """AHDI leaves LBA 1 as padding (matches HDDRIVER tooling); hybrid
     layouts put the DOS BPB at LBA 1 directly."""

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -89,7 +89,12 @@ BPB_ROOT_ENTRIES_OFFSET = 17
 BPB_TOTAL_SEC16_OFFSET = 19
 BPB_SEC_PER_FAT_OFFSET = 22
 
-# Canonical CHS geometry used by Hatari's script
+# CHS geometry baked into MBR partition entries. CHS is vestigial on
+# AHDI disks (which are LBA-only) and only present in MBR slots for
+# PC / DOS compatibility -- real Atari drivers ignore it. The 16x32
+# pair is the Hatari atari-hd-image.sh tooling convention, not a TOS
+# spec. Validated against the Atari Compendium notebook; see
+# CLAUDE.md.
 CHS_HEADS = 16
 CHS_SECTORS_PER_TRACK = 32
 
@@ -371,7 +376,18 @@ def build_root_sector_hddriver(plan: "ImagePlan") -> bytes:
     HDDRIVER convention: ONE primary (MBR P0) plus, when needed, an MBR
     extended container (next slot). AHDI slot 2 holds the TOS-view overlap
     marker for the primary partition -- one AHDI marker is all the
-    emulator's detector needs to classify the image as HDDRIVER."""
+    emulator's detector needs to classify the image as HDDRIVER.
+
+    The Atari Compendium describes HDDRIVER's hybrid trick as: place AHDI
+    partition info into MBR slot 2 with an MBR `part_type` of 0 so PC OSes
+    skip it, while the AHDI driver is told to look at 0x1DE specifically.
+    We achieve the type-0 byte *implicitly*: the AHDI entry's start-LBA
+    is stored big-endian at offset 0x1E2, which is exactly where MBR slot
+    2's `part_type` byte lives. For LBAs below 16 M (8 GiB at 512 B per
+    sector) the BE high byte is 0, so PC OSes correctly see no partition
+    in slot 2. Above that range the implicit type byte starts taking
+    non-zero values; not a concern within this tool's <= 2 GB envelope,
+    but worth knowing if the plan ever grows."""
     buf = bytearray(SECTOR_SIZE)
 
     # The one primary partition (always present).
@@ -937,10 +953,15 @@ def partition_cap_mb(format_id: str, strict_tos: bool,
                      partition_index: int) -> int:
     """Per-slot partition-size cap.
 
-    On AHDI the first partition is the TOS boot partition: it must be a
-    GEM entry, which TOS caps at 16 MB (< 1.04) or 32 MB (1.04+). Slots
-    2..N can be GEM (within the same threshold) or BGM (up to 256/512).
-    Hybrid formats have no per-slot distinction."""
+    On AHDI we conservatively treat the first partition as the boot
+    partition and clamp it to the GEM cap (16 MB strict / 32 MB
+    permissive) for legacy-driver compatibility. This is *not* a TOS
+    rule per se -- TOS itself only checks the boot flag, and modern
+    drivers boot from BGM up to 512 MB -- but the original AHDI and
+    early SCSI Tools required the GEM clamp, so we keep it. See
+    ahdi_partition_id() for the full rationale. Slots 2..N can be GEM
+    (within the same threshold) or BGM (up to 256/512). Hybrid formats
+    have no per-slot distinction."""
     if format_id == FORMAT_AHDI and partition_index == 0:
         return AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
     return format_max_partition_mb(format_id, strict_tos)
@@ -968,8 +989,16 @@ def cap_mb_for_type(format_id: str, strict_tos: bool,
 
 
 def first_partition_start_lba(format_id: str) -> int:
-    """AHDI leaves LBA 1 as padding (matches HDDRIVER tooling); hybrid
-    layouts put the DOS BPB at LBA 1 directly."""
+    """AHDI: physical LBA 1 is reserved for the Bad Sector List (BSL).
+    The root sector carries `bst_st` / `bst_cnt` pointers to it; we
+    don't emit a BSL on generated images (those fields stay at 0 = no
+    BSL), but we still leave LBA 1 vacant so a real driver writing a
+    BSL later doesn't have to relocate partition 0. The first
+    partition therefore starts at LBA 2.
+
+    Hybrid layouts (PPDRIVER / HDDRIVER): no AHDI BSL is involved; the
+    DOS BPB sits at LBA 1 directly. Validated against the Atari
+    Compendium notebook; see CLAUDE.md."""
     return 2 if format_id == FORMAT_AHDI else 1
 
 
@@ -1147,9 +1176,12 @@ def plan_image(format_id: str, image_path: str, image_mb: int,
     )
     plan.image_sectors = mb_to_sectors_512(image_mb)
 
-    # AHDI-only: enforce the TOS per-slot caps. Slot 0 is the boot (GEM)
-    # partition with a tighter 16/32 MB cap; slots 2..N follow the BGM
-    # 256/512 MB cap. Hybrid formats have no per-slot distinction.
+    # AHDI-only: enforce per-slot caps. Slot 0 is conservatively
+    # treated as the boot partition and clamped to the GEM cap (16/32
+    # MB) for legacy-driver compatibility -- not a hard TOS rule but a
+    # defensive default; see ahdi_partition_id() for the rationale.
+    # Slots 2..N follow the BGM 256/512 MB cap. Hybrid formats have no
+    # per-slot distinction.
     if format_id == FORMAT_AHDI:
         mode_label = "TOS < 1.04" if strict_tos else "TOS 1.04+"
         for i, part in enumerate(partitions):
@@ -1216,23 +1248,50 @@ def ahdi_partition_id(partition_mb: int, strict_tos: bool = False,
                       is_first: bool = False) -> bytes:
     """Pick the AHDI partition-id bytes for a partition of `partition_mb` MB.
 
-    The first AHDI partition is the TOS boot partition and must always be
-    GEM (TOS boots only from GEM entries). `is_first=True` forces GEM
-    regardless of size. Later partitions use the usual threshold: GEM when
-    the partition is <= the TOS-version GEM cap, BGM otherwise.
+    `is_first=True` forces b"GEM" regardless of size. This is a
+    *defensive compatibility* choice rather than a hard TOS requirement:
+    TOS itself only checks the boot flag (bit 7 of the partition-entry
+    flag byte), not the ident; modern drivers (HDDRIVER, PPDRIVER, ICD
+    Pro) happily boot from BGM up to 512 MB. But the original AHDI and
+    early SCSI Tools required ident == GEM and size <= 16 MB on the
+    boot slot, so emitting GEM at slot 0 is the broadest-compatibility
+    pick. Removing this clamp would let the user set up a 512 MB BGM
+    boot partition that works on modern drivers but fails on legacy
+    ones; revisit if a workflow actually wants that.
+
+    Later partitions use the usual threshold: GEM when partition_mb is
+    <= the TOS-version GEM cap, BGM otherwise. Note that the underlying
+    distinction is sector-size driven (GEM = bps 512, BGM = bps > 512);
+    the size threshold is what causes choose_logical_sector_size() to
+    flip bps, so size and ident move together.
 
     The GEM/BGM threshold differs between TOS versions: original TOS
-    (< 1.04) accepts GEM only up to 16 MB, while TOS 1.04+ extends that to
-    32 MB. `strict_tos=True` requests the conservative pre-1.04 rule."""
+    (< 1.04) accepts GEM only up to 16 MB, while TOS 1.04+ extends that
+    to 32 MB. `strict_tos=True` requests the conservative pre-1.04
+    rule."""
     if is_first:
         return b"GEM"
     threshold = AHDI_GEM_MAX_MB_STRICT if strict_tos else AHDI_GEM_MAX_MB
     return b"GEM" if partition_mb <= threshold else b"BGM"
 
 
-def build_image(plan: ImagePlan) -> None:
+def build_image(plan: ImagePlan, progress=None) -> None:
+    """Materialise `plan` to disk at `plan.image_path`.
+
+    `progress`, when not None, is invoked with a single string argument
+    at each major step of the pipeline (allocation, per-partition
+    format, BPB synthesis, root-sector write, extended-chain write).
+    Useful for surfacing progress in interactive callers (TUI). The
+    callback runs in the same thread as the writer; raising from it
+    aborts the build.
+    """
+    def _emit(msg):
+        if progress is not None:
+            progress(msg)
+
     # Step 1: allocate the image file (sparse where possible).
     image_bytes = plan.image_sectors * SECTOR_SIZE
+    _emit(f"Allocating {image_bytes // MIB} MB image...")
     try:
         with open(plan.image_path, "wb") as f:
             f.truncate(image_bytes)
@@ -1241,7 +1300,10 @@ def build_image(plan: ImagePlan) -> None:
 
     # Step 2: for each partition, format a temp file as FAT16 and splice
     # the bytes into the main image at the partition's physical offset.
-    for part in plan.partitions:
+    n = len(plan.partitions)
+    for i, part in enumerate(plan.partitions):
+        _emit(f"Writing partition {i + 1}/{n}: {part.name} "
+              f"({part.size_mb} MB)...")
         tmp_fd, tmp_path = tempfile.mkstemp(prefix="atari_hd_",
                                             suffix=".fatpart")
         os.close(tmp_fd)
@@ -1270,6 +1332,7 @@ def build_image(plan: ImagePlan) -> None:
     # the DOS BPB mkfs just wrote has bps=512, spc=2*ratio, res=ratio+1 so
     # the TOS companion's FAT/root/data LBAs align physically.
     if plan.format_id in (FORMAT_PPDRIVER, FORMAT_HDDRIVER):
+        _emit("Stamping TOS BPBs...")
         oem = b"PPGDODBC" if plan.format_id == FORMAT_PPDRIVER else None
         for part in plan.partitions:
             dos_bpb = read_sector(plan.image_path, part.start_lba)
@@ -1282,6 +1345,7 @@ def build_image(plan: ImagePlan) -> None:
             write_sector(plan.image_path, part.start_lba + 1, tos_bpb)
 
     # Step 4: write the root sector (sector 0) describing all partitions.
+    _emit("Writing partition table...")
     if plan.format_id == FORMAT_AHDI:
         root = build_root_sector_ahdi(plan)
     elif plan.format_id == FORMAT_PPDRIVER:
@@ -1299,6 +1363,7 @@ def build_image(plan: ImagePlan) -> None:
     # the next-link slot references the next descriptor (relative to the
     # chain's base = the first descriptor's LBA).
     if plan.has_extended:
+        _emit("Writing extended-chain descriptors...")
         logicals = plan.partitions[plan.primary_count:]
         chain_base = logicals[0].ebr_lba
         for i, part in enumerate(logicals):

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -185,6 +185,12 @@ DEFAULT_IMAGE_MB = {
 # would conventionally be 0x04 (FAT16A); we don't generate those
 # because the hybrid min cap is 32 MB. AHDI is unaffected (no MBR).
 MBR_TYPE_FAT16 = 0x06
+# MBR partition types we accept as FAT16-family primaries when loading
+# an image. 0x04 = FAT16A (legacy < 32 MB), 0x06 = FAT16B (>= 32 MB,
+# what this tool writes), 0x0E = FAT16 with LBA addressing. Other tools
+# (mkdosfs, acsi2stm, ICD) emit any of these; recognising all three lets
+# us load their output even though we only emit 0x06 ourselves.
+MBR_FAT16_TYPES = (0x04, 0x06, 0x0E)
 #
 # Extended-container type: PPDRIVER uses 0x0F (Win95 LBA-addressable
 # extended) to force LBA addressing on large disks. HDDRIVER uses
@@ -1276,10 +1282,14 @@ def detect_format(image_path: str):
       - 0x55AA at byte 510 -> MBR-style root sector. Then:
           * AHDI overlap at 0x1DE (flag bit 0 set, ident GEM/BGM)
             -> HDDRIVER's overlap trick.
-          * Else: read the first FAT16 primary's BPB and check for
-            OEM "PPGDODBC" -> PPDRIVER. Without the marker we
-            return None rather than falsely tagging vanilla DOS
-            MBR images as PPDRIVER.
+          * Else, walk MBR slots for any FAT16-family primary
+            (types 0x04 / 0x06 / 0x0E) whose BPB looks like a
+            FAT16 BPB (sane bps + spc) -> classify as PPDRIVER.
+            The PPDRIVER OEM 'PPGDODBC' is no longer required;
+            mkdosfs, acsi2stm and similar foreign tools emit
+            FAT16 images without that marker, and refusing to
+            load them was a UX dead end. The OEM mismatch is
+            surfaced by image_load_warnings() instead.
       - No 0x55AA + at least one valid AHDI slot (GEM/BGM/XGM)
         -> pure-AHDI image.
       - Anything else -> None (caller surfaces "format unknown").
@@ -1297,16 +1307,10 @@ def detect_format(image_path: str):
         if (ahdi_at_slot2["flag"] & AHDI_FLAG_EXISTENT) and (
                 ahdi_at_slot2["ident"] in (b"GEM", b"BGM")):
             return FORMAT_HDDRIVER
-        # PPDRIVER: walk MBR slots to find the first FAT16 primary,
-        # then check its BPB OEM. We stamp PPGDODBC on every
-        # partition's BPB at build time, so checking the first one
-        # is sufficient.
-        if _has_ppdriver_oem_marker(image_path, sec0):
+        if _has_any_fat16_primary(image_path, sec0):
             return FORMAT_PPDRIVER
-        # MBR-signed image without the HDDRIVER overlap and without
-        # the PPDRIVER OEM: not a recognised hybrid (vanilla DOS,
-        # foreign tooling, corrupt root, ...). Return None and let
-        # the caller surface "format unknown".
+        # MBR-signed but no FAT16-family primary with a sane BPB:
+        # not anything we know how to read.
         return None
     # No MBR signature -> pure AHDI if any slot has a valid ident.
     valid = (b"GEM", b"BGM", b"XGM")
@@ -1316,26 +1320,42 @@ def detect_format(image_path: str):
     return None
 
 
-def _has_ppdriver_oem_marker(image_path: str, sec0: bytes) -> bool:
-    """Return True iff the first FAT16 MBR primary's BPB carries the
-    PPDRIVER OEM marker. Conservative on errors (returns False) so a
-    bad read never produces a false-positive classification."""
+# bps values choose_logical_sector_size will ever pick + the Falcon
+# extras we accept on read (16384 / 32768) so we don't reject
+# Falcon-formatted images at detect time. The writer's narrower
+# acceptance is enforced separately in format_fat16().
+_BPS_ACCEPTED_FOR_LOAD = (512, 1024, 2048, 4096, 8192, 16384, 32768)
+
+
+def _has_any_fat16_primary(image_path: str, sec0: bytes) -> bool:
+    """Return True iff any MBR primary slot has a FAT16-family type
+    (0x04 / 0x06 / 0x0E) and its BPB at start_lba parses with sane
+    bps + spc. Conservative on errors: returns False so a bad read
+    never produces a false-positive classification."""
     try:
         mbr = parse_mbr_root(sec0)
-        for slot in mbr["slots"]:
-            if slot["part_type"] != MBR_TYPE_FAT16:
-                continue
-            start_lba = slot["rel_start_lba"]
+    except struct.error:
+        return False
+    for slot in mbr["slots"]:
+        if slot["part_type"] not in MBR_FAT16_TYPES:
+            continue
+        start_lba = slot["rel_start_lba"]
+        try:
             with open(image_path, "rb") as f:
-                f.seek(start_lba * SECTOR_SIZE)
+                f.seek(max(start_lba, 0) * SECTOR_SIZE)
                 bpb_sec = f.read(SECTOR_SIZE)
-            if len(bpb_sec) != SECTOR_SIZE:
-                return False
+        except OSError:
+            continue
+        if len(bpb_sec) != SECTOR_SIZE:
+            continue
+        try:
             bpb = parse_bpb(bpb_sec, 0)
-            return bpb["oem"] == PPDRIVER_OEM
-        return False
-    except (OSError, struct.error):
-        return False
+        except struct.error:
+            continue
+        if (bpb["bytes_per_sector"] in _BPS_ACCEPTED_FOR_LOAD
+                and bpb["sectors_per_cluster"] > 0):
+            return True
+    return False
 
 
 def _read_sector_at(image_path: str, lba: int, image_size: int) -> bytes:
@@ -1443,8 +1463,8 @@ def _load_mbr(image_path: str, sec0: bytes, image_size: int,
             ext_base = slot["rel_start_lba"]
             ext_link = slot["rel_start_lba"]
             continue
-        if ptype != MBR_TYPE_FAT16:
-            # Unknown partition type; skip.
+        if ptype not in MBR_FAT16_TYPES:
+            # Unknown / non-FAT16 partition type; skip.
             continue
         partitions.append(_partition_from_mbr(
             image_path, image_size,
@@ -1523,6 +1543,60 @@ def _infer_strict_tos(partitions) -> bool:
     return True
 
 
+def image_load_warnings(image_path: str, sec0: bytes,
+                         partitions, fmt) -> list:
+    """Collect non-fatal compatibility warnings about an image we just
+    loaded. Each warning is a short human-readable string the TUI can
+    surface in the status bar after `L = Load`. Returns an empty list
+    when the image is a clean match for our writer.
+
+    detect_format() now accepts MBR+FAT16 images regardless of OEM and
+    of the specific FAT16 type byte; warnings here record the deltas
+    from our canonical PPDRIVER output (OEM, type=0x06, start_lba>=1,
+    bps<=8192) so the user knows what re-saving will normalise vs.
+    what would produce a broken image.
+    """
+    warnings = []
+    if fmt != FORMAT_PPDRIVER:
+        return warnings
+    try:
+        mbr = parse_mbr_root(sec0)
+    except struct.error:
+        return warnings
+    first_fat = None
+    for slot in mbr["slots"]:
+        if slot["part_type"] in MBR_FAT16_TYPES:
+            first_fat = slot
+            break
+    if first_fat is None:
+        return warnings
+    if first_fat["part_type"] != MBR_TYPE_FAT16:
+        warnings.append(
+            f"primary uses MBR type 0x{first_fat['part_type']:02X} "
+            f"(this tool writes 0x06; re-saving will normalise)")
+    if first_fat["rel_start_lba"] == 0:
+        warnings.append(
+            "partition starts at LBA 0 (superfloppy layout); re-saving "
+            "will move it to LBA 1")
+    try:
+        with open(image_path, "rb") as f:
+            f.seek(max(first_fat["rel_start_lba"], 0) * SECTOR_SIZE)
+            bpb_sec = f.read(SECTOR_SIZE)
+        if len(bpb_sec) == SECTOR_SIZE:
+            bpb = parse_bpb(bpb_sec, 0)
+            if bpb["oem"] != PPDRIVER_OEM:
+                warnings.append(
+                    f"BPB OEM {bpb['oem']!r} != {PPDRIVER_OEM!r}; "
+                    "re-saving overwrites it")
+            if bpb["bytes_per_sector"] > 8192:
+                warnings.append(
+                    f"BPB bps={bpb['bytes_per_sector']} unsupported by "
+                    "this writer (max 8192) - image is read-only here")
+    except (OSError, struct.error):
+        pass
+    return warnings
+
+
 def load_image(image_path: str) -> dict:
     """Parse an existing image and return a planning summary:
         {
@@ -1530,6 +1604,7 @@ def load_image(image_path: str) -> dict:
           "strict_tos": bool,         # AHDI-only inference
           "partitions": list[Partition],
           "strict_tos_inferred": bool, # True iff we guessed
+          "warnings": list[str],      # non-fatal compatibility notes
         }
     Raises ImageLoadError on unrecognised or corrupt images."""
     try:
@@ -1567,6 +1642,7 @@ def load_image(image_path: str) -> dict:
         "strict_tos": strict_tos,
         "strict_tos_inferred": strict_inferred,
         "partitions": partitions,
+        "warnings": image_load_warnings(image_path, sec0, partitions, fmt),
     }
 
 

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -1466,7 +1466,8 @@ def _load_ahdi(image_path: str, sec0: bytes, image_size: int):
             {"flag": logical["flag"], "ident": logical["ident"],
              "start_lba": abs_start,
              "size_sectors": logical["size_sectors"]},
-            slot_index=len(partitions)))
+            slot_index=len(partitions),
+            ebr_lba=chain_link))
         link = desc["link"]
         if not (link["flag"] & AHDI_FLAG_EXISTENT):
             break
@@ -1533,11 +1534,18 @@ def _load_mbr(image_path: str, sec0: bytes, image_size: int,
 
 
 def _partition_from_entry(image_path: str, image_size: int, entry: dict,
-                          slot_index: int) -> "Partition":
+                          slot_index: int, ebr_lba: int = 0) -> "Partition":
     """Build a Partition from an AHDI-table entry, recovering the label
     from the FAT16 BPB at start_lba. AHDI partitions live at bps =
     Hatari-doubling-rule(size_sectors); we use that convention to
-    locate the BPB."""
+    locate the BPB.
+
+    `ebr_lba` is 0 for partitions recovered from AHDI primary slots
+    (slots 0..3 of the root sector) and the absolute LBA of the XGM
+    sub-descriptor sector for chain logicals -- analogous to the
+    MBR-side _partition_from_mbr's ebr_lba so the rest of the tool
+    can use a single field to distinguish primary from logical
+    regardless of format."""
     size_sec = entry["size_sectors"]
     size_mb = (size_sec * SECTOR_SIZE) // MIB
     default = f"P{slot_index + 1}"
@@ -1545,7 +1553,8 @@ def _partition_from_entry(image_path: str, image_size: int, entry: dict,
                             default=default)
     p = Partition(name=name, size_mb=size_mb,
                    size_sectors=size_sec,
-                   start_lba=entry["start_lba"])
+                   start_lba=entry["start_lba"],
+                   ebr_lba=ebr_lba)
     ident = entry["ident"]
     p.ahdi_ident = (ident.decode("ascii", errors="replace")
                     if isinstance(ident, (bytes, bytearray)) else ident)

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -687,11 +687,15 @@ FAT16_EXTENDED_BOOT_SIG = 0x29
 FAT16_DRIVE_NUMBER = 0x80
 FAT16_VOLUME_LABEL_ATTR = 0x08
 
-# Boot-code stub fill: HLT (0xF4). mkfs.vfat ships its own x86 stub that
-# prints "Non-system disk"; we never boot x86 from these images, so a
-# one-byte HLT pattern is fine. The byte-parity harness in epic-001 /
-# story 003 may mask this region if mkfs.vfat drift is observed.
-FAT16_BOOT_CODE_FILL = 0xF4
+# Boot-code stub fill. Real PPDRIVER PPTOSDOS images zero this region
+# (verified by byte-level diff of /Volumes/SIDECART/1GB-RAWDUMP.img
+# against ours); using 0xF4 (HLT) here was an arbitrary historical
+# choice that confused real-driver detection of the PPDRIVER format
+# on the user's hardware. Switching to 0x00 universally so all output
+# matches real PPDRIVER's "minimal BPB + zero pad + 0x55AA" layout in
+# this region. AHDI / HDDRIVER are unaffected -- neither boots x86
+# code from this region; the byte-parity harness already masks it.
+FAT16_BOOT_CODE_FILL = 0x00
 
 # Boot-sector field offsets not covered by the BPB_* constants above.
 FAT16_BS_MEDIA_OFFSET = 0x15
@@ -829,9 +833,20 @@ def _fat16_validate_and_compute_spfat(partition_sectors_512: int,
 def _fat16_build_boot_sector(sector_size: int, sectors_per_cluster: int,
                              reserved_sectors: int, spfat: int,
                              total_sectors_logical: int, label: bytes,
-                             volume_id: int) -> bytes:
+                             volume_id: int,
+                             strip_ebpb: bool = False) -> bytes:
     """Assemble the 512-byte FAT16 boot sector. When sector_size > 512 the
-    rest of logical sector 0 is zero-filled separately by the caller."""
+    rest of logical sector 0 is zero-filled separately by the caller.
+
+    `strip_ebpb=True` zeroes the EBPB tail (bytes 24..62: spt, heads,
+    drive_number, boot_sig, volume_id, volume_label, fs_type) so the
+    output matches real PPDRIVER's minimal-BPB layout. mkfs.vfat-style
+    images keep the full EBPB (default False); hybrid images
+    (PPDRIVER / HDDRIVER) need the strip because real PPDRIVER's
+    setup tool produces a stripped BPB and the user's driver detects
+    the format by inspecting that region. The volume label is still
+    available via the FAT16 root-directory volume-label entry, which
+    is unaffected by this strip."""
     bs = bytearray(SECTOR_SIZE)
     bs[0:3] = b"\xEB\x3C\x90"  # jmp 0x3E ; nop
     bs[BPB_OEM_OFFSET:BPB_OEM_OFFSET + BPB_OEM_LENGTH] = FAT16_OEM_NAME
@@ -851,19 +866,24 @@ def _fat16_build_boot_sector(sector_size: int, sectors_per_cluster: int,
                          total_sectors_logical)
     bs[FAT16_BS_MEDIA_OFFSET] = FAT16_MEDIA_DESCRIPTOR
     struct.pack_into("<H", bs, BPB_SEC_PER_FAT_OFFSET, spfat)
-    struct.pack_into("<H", bs, FAT16_BS_SPT_OFFSET, FAT16_SECTORS_PER_TRACK)
-    struct.pack_into("<H", bs, FAT16_BS_HEADS_OFFSET, FAT16_NUM_HEADS)
-    # FAT16_BS_HIDDEN_OFFSET stays at 0; partition offset lives in the
-    # caller's partition table, not in this BPB.
 
-    bs[FAT16_BS_DRIVE_OFFSET] = FAT16_DRIVE_NUMBER
-    bs[FAT16_BS_RESERVED1_OFFSET] = 0
-    bs[FAT16_BS_BOOTSIG_OFFSET] = FAT16_EXTENDED_BOOT_SIG
-    struct.pack_into("<I", bs, FAT16_BS_VOLID_OFFSET,
-                     volume_id & 0xFFFFFFFF)
-    bs[FAT16_BS_LABEL_OFFSET:FAT16_BS_LABEL_OFFSET + 11] = \
-        label.ljust(11, b" ")
-    bs[FAT16_BS_FSTYPE_OFFSET:FAT16_BS_FSTYPE_OFFSET + 8] = FAT16_FS_TYPE
+    if not strip_ebpb:
+        struct.pack_into("<H", bs, FAT16_BS_SPT_OFFSET,
+                         FAT16_SECTORS_PER_TRACK)
+        struct.pack_into("<H", bs, FAT16_BS_HEADS_OFFSET, FAT16_NUM_HEADS)
+        # FAT16_BS_HIDDEN_OFFSET stays at 0; partition offset lives in the
+        # caller's partition table, not in this BPB.
+
+        bs[FAT16_BS_DRIVE_OFFSET] = FAT16_DRIVE_NUMBER
+        bs[FAT16_BS_RESERVED1_OFFSET] = 0
+        bs[FAT16_BS_BOOTSIG_OFFSET] = FAT16_EXTENDED_BOOT_SIG
+        struct.pack_into("<I", bs, FAT16_BS_VOLID_OFFSET,
+                         volume_id & 0xFFFFFFFF)
+        bs[FAT16_BS_LABEL_OFFSET:FAT16_BS_LABEL_OFFSET + 11] = \
+            label.ljust(11, b" ")
+        bs[FAT16_BS_FSTYPE_OFFSET:FAT16_BS_FSTYPE_OFFSET + 8] = FAT16_FS_TYPE
+    # When strip_ebpb is True, bytes 24..62 stay at their bytearray
+    # default (zero) -- matching real PPDRIVER exactly.
 
     bs[FAT16_BS_BOOTCODE_OFFSET:FAT16_BS_SIGNATURE_OFFSET] = \
         bytes((FAT16_BOOT_CODE_FILL,)) * \
@@ -902,7 +922,8 @@ def format_fat16(out_path: str,
                  sectors_per_cluster: int,
                  reserved_sectors: int,
                  label: str,
-                 disable_fat_align: bool) -> None:
+                 disable_fat_align: bool,
+                 strip_ebpb: bool = False) -> None:
     """Write a freshly formatted, empty FAT16 image to `out_path`.
 
     Reproduces the on-disk layout that mkfs.vfat -F 16 produces for the
@@ -941,6 +962,7 @@ def format_fat16(out_path: str,
         total_sectors_logical=total_sectors_logical,
         label=label_bytes,
         volume_id=volume_id,
+        strip_ebpb=strip_ebpb,
     )
 
     # First sector of each FAT: F8 FF FF FF (FAT[0]=media descriptor,
@@ -993,7 +1015,8 @@ def format_fat16(out_path: str,
 def run_mkfs(out_path: str,
              partition_sectors_512: int, sector_size: int,
              sectors_per_cluster: int, reserved_sectors: int,
-             label: str, disable_fat_align: bool) -> None:
+             label: str, disable_fat_align: bool,
+             strip_ebpb: bool = False) -> None:
     """Thin wrapper around format_fat16(). Kept as a separate entry point
     so future callers can interpose logging / retries / metrics without
     touching every call site."""
@@ -1005,6 +1028,7 @@ def run_mkfs(out_path: str,
         reserved_sectors=reserved_sectors,
         label=label,
         disable_fat_align=disable_fat_align,
+        strip_ebpb=strip_ebpb,
     )
 
 
@@ -2194,6 +2218,11 @@ def build_image(plan: ImagePlan, progress=None) -> None:
                 reserved_sectors=part.dos_res,
                 label=part.name,
                 disable_fat_align=(plan.format_id != FORMAT_AHDI),
+                # Hybrid formats need a stripped EBPB to match real
+                # PPDRIVER / HDDRIVER bytes; AHDI keeps the standard
+                # full EBPB (real HDDRIVER pure-AHDI images carry it
+                # too -- e.g. /Volumes/TESTDEV/Atari4gb.vhd).
+                strip_ebpb=(plan.format_id != FORMAT_AHDI),
             )
             partition_offset_bytes = part.start_lba * SECTOR_SIZE
             copy_file_into_image(tmp_path, plan.image_path,

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -1522,7 +1522,8 @@ def _load_mbr(image_path: str, sec0: bytes, image_size: int,
             image_path, image_size,
             start_lba=abs_start,
             size_sectors=slot0["sector_count"],
-            slot_index=len(partitions)))
+            slot_index=len(partitions),
+            ebr_lba=ext_link))
         slot1 = ebr["slots"][1]
         if slot1["part_type"] not in MBR_EXTENDED_TYPES:
             break
@@ -1553,15 +1554,23 @@ def _partition_from_entry(image_path: str, image_size: int, entry: dict,
 
 def _partition_from_mbr(image_path: str, image_size: int,
                         start_lba: int, size_sectors: int,
-                        slot_index: int) -> "Partition":
+                        slot_index: int,
+                        ebr_lba: int = 0) -> "Partition":
     """Build a Partition from an MBR/EBR FAT16 entry. The DOS BPB lives
-    at start_lba (bps=512 for the dual-BPB DOS view)."""
+    at start_lba (bps=512 for the dual-BPB DOS view).
+
+    `ebr_lba` is 0 for partitions recovered from MBR primary slots and
+    the absolute LBA of the partition's EBR sector for chain logicals.
+    Round-trip with build_image expects this distinction so the writer
+    can put primaries back at MBR slots and logicals back in the
+    extended chain."""
     size_mb = (size_sectors * SECTOR_SIZE) // MIB
     default = f"P{slot_index + 1}"
     name = _label_from_bpb(image_path, start_lba, image_size,
                             default=default)
     p = Partition(name=name, size_mb=size_mb,
-                   size_sectors=size_sectors, start_lba=start_lba)
+                   size_sectors=size_sectors, start_lba=start_lba,
+                   ebr_lba=ebr_lba)
     return p
 
 

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -1713,13 +1713,61 @@ def load_image(image_path: str) -> dict:
     strict_inferred = (fmt == FORMAT_AHDI)
     strict_tos = _infer_strict_tos(partitions) if strict_inferred else False
 
+    extra_warnings = []
+    if fmt in (FORMAT_PPDRIVER, FORMAT_HDDRIVER):
+        extra_warnings.extend(_migrate_legacy_layout(partitions, fmt))
+
     return {
         "format_id": fmt,
         "strict_tos": strict_tos,
         "strict_tos_inferred": strict_inferred,
         "partitions": partitions,
-        "warnings": image_load_warnings(image_path, sec0, partitions, fmt),
+        "warnings": (image_load_warnings(image_path, sec0, partitions, fmt)
+                     + extra_warnings),
     }
+
+
+def _migrate_legacy_layout(partitions, format_id) -> list:
+    """In-place auto-migration of partitions loaded from images built
+    with the prior N-driven layout (where 1..4 partitions on PPDRIVER
+    were all primaries regardless of size). The new per-partition rule
+    caps primaries at HYBRID_PRIMARY_MAX_MB; any on-disk primary above
+    that ceiling can't be re-saved as a primary, so we flip its
+    is_extended flag. To preserve the "primaries must come before
+    extendeds" invariant, every partition that follows the first
+    flipped slot is also marked extended (otherwise re-saving would
+    fail validation with a "primary after extended" error).
+
+    HDDRIVER's primary cap of 1 (slot 0 only) means slots >= 1 also
+    must be extended even when their size <= 255 MB; the same loop
+    catches that by treating "extra primaries" exactly like "oversize
+    primaries" -- both end up forced to extended.
+
+    Returns a list of human-readable warnings the caller can surface
+    in the TUI status bar."""
+    warnings = []
+    seen_extended = False
+    primary_count = 0
+    max_primaries = MAX_PRIMARY_PARTITIONS[format_id]
+    for i, p in enumerate(partitions):
+        if p.is_extended:
+            seen_extended = True
+            continue
+        oversize = p.size_mb > HYBRID_PRIMARY_MAX_MB
+        too_many = primary_count >= max_primaries
+        if seen_extended or oversize or too_many:
+            p.is_extended = True
+            seen_extended = True
+            reason = ("size > 255 MB" if oversize
+                      else "exceeds primary cap" if too_many
+                      else "follows extended")
+            warnings.append(
+                f"slot {i} ({p.name!r}, {p.size_mb} MB): "
+                f"auto-flipped to extended ({reason}); "
+                "re-saving will move it into the extended chain")
+        else:
+            primary_count += 1
+    return warnings
 
 
 def first_partition_start_lba(format_id: str) -> int:

--- a/scripts/atari-hd/atari_hd.py
+++ b/scripts/atari-hd/atari_hd.py
@@ -144,7 +144,7 @@ SECTOR_SIZE_WARN_THRESHOLD = 8192
 # which is the ceiling for every format once the extended chain is in play.
 MAX_PARTITIONS = {
     FORMAT_AHDI: 14,       # up to 4 primary, rest via XGM chain
-    FORMAT_PPDRIVER: 14,   # up to 4 primary, rest via MBR extended chain
+    FORMAT_PPDRIVER: 14,   # 1 primary + rest via MBR extended chain
     FORMAT_HDDRIVER: 14,   # 1 primary max, rest via MBR extended chain
 }
 
@@ -155,7 +155,7 @@ MAX_PARTITIONS = {
 # remaining partitions live as logicals inside that chain.
 MAX_PRIMARY_PARTITIONS = {
     FORMAT_AHDI: 4,        # 4 AHDI root slots; slot 3 becomes XGM when N>4
-    FORMAT_PPDRIVER: 4,    # full MBR primary use when N <= 4
+    FORMAT_PPDRIVER: 1,    # PPTOSDOS convention: one primary + extended chain
     FORMAT_HDDRIVER: 1,    # HDDRIVER convention: one primary + AHDI marker
 }
 
@@ -414,10 +414,15 @@ def extended_container_bounds(plan: "ImagePlan") -> tuple:
 def build_root_sector_ppdriver(plan: "ImagePlan") -> bytes:
     """PPera TOS&DOS root sector.
 
-    Primary partitions (up to 4) occupy MBR slots 0..primary_count-1. When
-    more partitions were requested, the next slot is an extended container
-    (type 0x0F) covering the logical partitions in the EBR chain. The dual
-    BPB per partition lives inside the partition itself, not here."""
+    The first partition occupies MBR slot 0 as a FAT16B primary; any
+    additional partitions live in the LBA-extended chain (MBR slot 1
+    holds the type-0x0F container, the EBRs sit inside it). Older
+    revisions of this tool put up to 4 primaries here, but multi-
+    primary PPDRIVER images fail on real Atari hardware once a slot
+    crosses ~256 MB -- the documented PPTOSDOS convention is single-
+    primary + extended, which is what real PPDRIVER setup tools
+    produce. The dual BPB per partition lives inside the partition
+    itself, not here."""
     buf = bytearray(SECTOR_SIZE)
 
     for i in range(plan.primary_count):
@@ -1574,10 +1579,13 @@ def partition_layout(format_id: str, n: int) -> dict:
     extended chain.
 
     - AHDI: up to 4 primary (AHDI-table slots); no extended support in v1.
-    - PPDRIVER: up to MAX_PRIMARY_PARTITIONS (4). When N > 4, fall back
-      to the standard DOS convention of (cap-1) primaries plus one MBR
-      extended container holding the rest as logicals (3 primary + N-3
-      logical, up to 14 total).
+    - PPDRIVER: ONE primary + the rest in an MBR extended container.
+      Matches the documented PPTOSDOS convention. Hardware testing
+      confirmed multi-primary PPDRIVER images at >256 MB partition
+      sizes fail to read parts of the filesystem on real Atari
+      hardware (validated against the Compendium notebook); the
+      single-primary layout is what real PPDRIVER setup tools
+      produce.
     - HDDRIVER: one primary plus an extended container. Matches the
       real-world HDDRIVER TOS&DOS hybrid layout.
 
@@ -1600,13 +1608,15 @@ def partition_layout(format_id: str, n: int) -> dict:
                 "logical_count": n - primary}
 
     if format_id == FORMAT_PPDRIVER:
-        if n <= MAX_PRIMARY_PARTITIONS[FORMAT_PPDRIVER]:
-            # All primary; no extended container needed.
-            return {"primary_count": n, "has_extended": False,
+        # PPTOSDOS convention: one primary slot, every other partition
+        # in the LBA-extended chain (MBR type 0x0F). Using multiple
+        # primaries breaks real Atari hardware reads at >256 MB
+        # partition sizes (verified empirically; see partition_layout
+        # docstring).
+        primary = MAX_PRIMARY_PARTITIONS[FORMAT_PPDRIVER]   # always 1
+        if n == primary:
+            return {"primary_count": primary, "has_extended": False,
                     "logical_count": 0}
-        # Use (cap - 1) primaries + 1 MBR extended container. With the 4-slot
-        # MBR that's 3 primary + 1 extended, holding N-3 logicals.
-        primary = MAX_PRIMARY_PARTITIONS[FORMAT_PPDRIVER] - 1
         return {"primary_count": primary, "has_extended": True,
                 "logical_count": n - primary}
 

--- a/scripts/atari-hd/tests/_support.py
+++ b/scripts/atari-hd/tests/_support.py
@@ -6,9 +6,12 @@ Tests import the script under test via:
 
 The sys.path manipulation below makes that import resolve to
 scripts/atari-hd/atari_hd.py regardless of the caller's cwd.
+
+Partition-table parsers themselves now live in atari_hd.py (lifted
+there in epic-003 / story 007 so the TUI can use them too); we
+re-export here to keep the test-side import path stable.
 """
 
-import struct
 import sys
 from pathlib import Path
 
@@ -20,129 +23,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import atari_hd  # noqa: E402
 
-
-# AHDI root-sector slot offsets (12 bytes per slot).
-AHDI_SLOT_OFFSETS = (0x1C6, 0x1D2, 0x1DE, 0x1EA)
-
-# MBR root-sector slot offsets (16 bytes per slot).
-MBR_SLOT_OFFSETS = (0x1BE, 0x1CE, 0x1DE, 0x1EE)
-
-
-def parse_ahdi_entry(buf, offset):
-    """Parse a 12-byte AHDI entry at `offset` in `buf`.
-
-    Layout (big-endian for the two 32-bit fields, per the AHDI/Atari
-    convention):
-        +0   flag        (1 byte)
-        +1   ident       (3 bytes)  e.g. b"GEM" / b"BGM" / b"XGM"
-        +4   start_lba   (4 bytes, big-endian)
-        +8   size        (4 bytes, big-endian)
-    """
-    start_lba, size_sectors = struct.unpack_from(">II", buf, offset + 4)
-    return {
-        "flag":         buf[offset],
-        "ident":        bytes(buf[offset + 1:offset + 4]),
-        "start_lba":    start_lba,
-        "size_sectors": size_sectors,
-    }
-
-
-def parse_ahdi_root(buf):
-    """Parse the four AHDI slots from a root sector. Returns a list of
-    four dicts (empty slots come back with flag=0 / ident=b'\\x00\\x00\\x00')."""
-    return [parse_ahdi_entry(buf, off) for off in AHDI_SLOT_OFFSETS]
-
-
-def parse_mbr_entry(buf, offset):
-    """Parse a 16-byte MBR partition entry at `offset` in `buf`.
-
-    Layout (little-endian for the two 32-bit fields, per IBM/Microsoft
-    MBR convention):
-        +0   boot          (1 byte; 0x80 marks active/bootable)
-        +1   chs_first     (3 bytes; encoded by pack_chs)
-        +4   part_type     (1 byte)
-        +5   chs_last      (3 bytes)
-        +8   rel_start_lba (4 bytes, little-endian; for EBRs this is
-                            relative to the EBR sector or the chain base)
-        +12  sector_count  (4 bytes, little-endian)
-    """
-    rel_start_lba, sector_count = struct.unpack_from("<II", buf, offset + 8)
-    return {
-        "boot":          buf[offset],
-        "chs_first":     bytes(buf[offset + 1:offset + 4]),
-        "part_type":     buf[offset + 4],
-        "chs_last":      bytes(buf[offset + 5:offset + 8]),
-        "rel_start_lba": rel_start_lba,
-        "sector_count":  sector_count,
-    }
-
-
-def parse_mbr_root(buf):
-    """Parse the four MBR slots + the 0x55AA signature. Returns
-    {"slots": [<4 dicts>], "signature": bytes(2)}."""
-    return {
-        "slots":     [parse_mbr_entry(buf, off) for off in MBR_SLOT_OFFSETS],
-        "signature": bytes(buf[510:512]),
-    }
-
-
-def parse_ebr(buf):
-    """An EBR has the same on-disk layout as an MBR root (4 slot positions
-    + signature); only slots 0 and 1 are populated in practice."""
-    return parse_mbr_root(buf)
-
-
-def parse_xgm_descriptor(buf):
-    """Parse an AHDI XGM sub-descriptor: slot 0 = logical partition,
-    slot 1 = next-descriptor link (or empty when chain ends). Slots 2/3
-    are unused; no MBR signature."""
-    return {
-        "logical": parse_ahdi_entry(buf, AHDI_SLOT_OFFSETS[0]),
-        "link":    parse_ahdi_entry(buf, AHDI_SLOT_OFFSETS[1]),
-    }
-
-
-def parse_bpb(buf, offset):
-    """Parse the BPB / extended boot record at `offset` in a FAT16 boot
-    sector buffer. Returns every documented field as a plain int or bytes
-    value.
-
-    Layout follows the Microsoft / mkfs.fat convention; multi-byte fields
-    are little-endian. Pure struct.unpack_from for the integer fields.
-    """
-    base = offset
-    return {
-        "jump":                    bytes(buf[base + 0x00:base + 0x03]),
-        "oem":                     bytes(buf[base + 0x03:base + 0x0B]),
-        "bytes_per_sector":        struct.unpack_from(
-                                       "<H", buf, base + 0x0B)[0],
-        "sectors_per_cluster":     buf[base + 0x0D],
-        "reserved_sectors":        struct.unpack_from(
-                                       "<H", buf, base + 0x0E)[0],
-        "num_fats":                buf[base + 0x10],
-        "root_entries":            struct.unpack_from(
-                                       "<H", buf, base + 0x11)[0],
-        "total_sectors_16":        struct.unpack_from(
-                                       "<H", buf, base + 0x13)[0],
-        "media_descriptor":        buf[base + 0x15],
-        "sectors_per_fat_16":      struct.unpack_from(
-                                       "<H", buf, base + 0x16)[0],
-        "sectors_per_track":       struct.unpack_from(
-                                       "<H", buf, base + 0x18)[0],
-        "num_heads":               struct.unpack_from(
-                                       "<H", buf, base + 0x1A)[0],
-        "hidden_sectors":          struct.unpack_from(
-                                       "<I", buf, base + 0x1C)[0],
-        "total_sectors_32":        struct.unpack_from(
-                                       "<I", buf, base + 0x20)[0],
-        "drive_number":            buf[base + 0x24],
-        "extended_boot_signature": buf[base + 0x26],
-        "volume_id":               struct.unpack_from(
-                                       "<I", buf, base + 0x27)[0],
-        "volume_label":            bytes(buf[base + 0x2B:base + 0x36]),
-        "fs_type":                 bytes(buf[base + 0x36:base + 0x3E]),
-        "signature":               bytes(buf[base + 0x1FE:base + 0x200]),
-    }
+# Re-export parsers + slot-offset tuples for the existing test imports.
+AHDI_SLOT_OFFSETS = atari_hd.AHDI_SLOT_OFFSETS
+MBR_SLOT_OFFSETS = atari_hd.MBR_SLOT_OFFSETS
+parse_ahdi_entry = atari_hd.parse_ahdi_entry
+parse_ahdi_root = atari_hd.parse_ahdi_root
+parse_mbr_entry = atari_hd.parse_mbr_entry
+parse_mbr_root = atari_hd.parse_mbr_root
+parse_ebr = atari_hd.parse_ebr
+parse_xgm_descriptor = atari_hd.parse_xgm_descriptor
+parse_bpb = atari_hd.parse_bpb
 
 
 # 512-byte physical sector. Used by the chain walker; copied here rather
@@ -210,7 +100,10 @@ def _walk_ahdi(image_path, sec0):
 
 
 # MBR partition type for an extended (LBA) container.
-_MBR_TYPE_EXTENDED = 0x0F
+# Extended-container type bytes recognised by the walker. PPDRIVER
+# emits 0x0F (LBA); HDDRIVER emits 0x05 (CHS). Both are valid markers
+# for an extended chain.
+_MBR_EXTENDED_TYPES = atari_hd.MBR_EXTENDED_TYPES
 
 
 def _walk_mbr(image_path, sec0):
@@ -221,7 +114,7 @@ def _walk_mbr(image_path, sec0):
     for slot in mbr["slots"]:
         if slot["part_type"] == 0:
             continue
-        if slot["part_type"] == _MBR_TYPE_EXTENDED:
+        if slot["part_type"] in _MBR_EXTENDED_TYPES:
             ext_base = slot["rel_start_lba"]
             ext_link = slot["rel_start_lba"]
             continue
@@ -241,7 +134,7 @@ def _walk_mbr(image_path, sec0):
             "part_type":    logical["part_type"],
         })
         link = ebr["slots"][1]
-        if link["part_type"] == 0:
+        if link["part_type"] not in _MBR_EXTENDED_TYPES:
             break
         # Next-EBR link's start is RELATIVE to the chain base.
         ext_link = ext_base + link["rel_start_lba"]

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -45,8 +45,12 @@ class TestPartitionCapMb(unittest.TestCase):
             atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, True, 1), 256)
 
     def test_ahdi_permissive_bgm_cap(self):
+        # 511 MB, not 512: the documented "512 MB BGM" is rounded up.
+        # Real ceiling is NSECTS=65535 at bps=8192 = 511.99 MB. A 512 MB
+        # plan trips the Hatari sector-doubling rule into bps=16384,
+        # which TOS 1.04 - 3.x doesn't support.
         self.assertEqual(
-            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, False, 1), 512)
+            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, False, 1), 511)
 
     def test_ahdi_strict_bgm_cap_holds_for_higher_slots(self):
         # Slots 2..N share the BGM cap with slot 1.
@@ -58,15 +62,18 @@ class TestPartitionCapMb(unittest.TestCase):
 
     def test_hybrid_caps_have_no_per_slot_distinction(self):
         # PPDRIVER / HDDRIVER go through the DOS view, which doesn't care
-        # about TOS BGM limits. Cap is the FAT16 ceiling regardless of
-        # slot or strict flag.
+        # about TOS BGM limits. The cap is the hybrid layout ceiling
+        # (511 MB; TOS NSECTS 16-bit max at bps=8192) regardless of
+        # slot or strict flag. The strict flag is meaningless for
+        # hybrids -- they target TOS 1.04+ exclusively (synthesize
+        # rejects ratio < 2 / tos_bps < 1024).
         for fmt in (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER):
             for slot in (0, 1, 5, 13):
                 for strict in (True, False):
                     with self.subTest(format=fmt, slot=slot, strict=strict):
                         self.assertEqual(
                             atari_hd.partition_cap_mb(fmt, strict, slot),
-                            atari_hd.MAX_PARTITION_MB)
+                            atari_hd.HYBRID_MAX_PARTITION_MB)
 
 
 class TestCapMbForType(unittest.TestCase):
@@ -86,7 +93,7 @@ class TestCapMbForType(unittest.TestCase):
                     32)
 
     def test_ahdi_bgm_cap_regardless_of_slot(self):
-        # User picks BGM -> BGM cap (256 strict, 512 perm).
+        # User picks BGM -> BGM cap (256 strict, 511 perm).
         for ident in (b"BGM", "BGM"):
             with self.subTest(ident=ident):
                 self.assertEqual(
@@ -94,28 +101,31 @@ class TestCapMbForType(unittest.TestCase):
                     256)
                 self.assertEqual(
                     atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, ident),
-                    512)
+                    511)
 
     def test_unknown_ahdi_ident_falls_back_to_bgm_cap(self):
         # Defensive: anything other than GEM uses the BGM cap.
         self.assertEqual(
             atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, b"XGM"),
-            512)
+            511)
         self.assertEqual(
             atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, None),
-            512)
+            511)
 
     def test_hybrid_ignores_ident(self):
-        # PPDRIVER / HDDRIVER use the FAT16 ceiling regardless.
+        # PPDRIVER / HDDRIVER use the hybrid-layout ceiling regardless
+        # of ident or strict_tos. The cap (511 MB) comes from the TOS
+        # NSECTS 16-bit limit at the maximum supported TOS bps of
+        # 8192 -- not the FAT16 cluster ceiling.
         for fmt in (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER):
             for ident in (b"GEM", b"BGM", None, "FAT16"):
                 with self.subTest(format=fmt, ident=ident):
                     self.assertEqual(
                         atari_hd.cap_mb_for_type(fmt, False, ident),
-                        atari_hd.MAX_PARTITION_MB)
+                        atari_hd.HYBRID_MAX_PARTITION_MB)
                     self.assertEqual(
                         atari_hd.cap_mb_for_type(fmt, True, ident),
-                        atari_hd.MAX_PARTITION_MB)
+                        atari_hd.HYBRID_MAX_PARTITION_MB)
 
 
 class TestAhdiPartitionId(unittest.TestCase):
@@ -274,7 +284,7 @@ class TestRejectionPaths(unittest.TestCase):
         self.assertIn("boot (GEM)", msg, msg)
 
     def test_ahdi_permissive_bgm_partition_over_cap(self):
-        # 600 MB > 512 MB permissive BGM cap.
+        # 600 MB > 511 MB permissive BGM cap.
         partitions = [
             atari_hd.Partition(name="BOOT", size_mb=32),
             atari_hd.Partition(name="HUGE", size_mb=600),

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -66,6 +66,55 @@ class TestPartitionCapMb(unittest.TestCase):
                             atari_hd.MAX_PARTITION_MB)
 
 
+class TestCapMbForType(unittest.TestCase):
+    """cap_mb_for_type returns the cap for a partition based on the
+    user-chosen type ident. Used by interactive callers (TUI edit
+    dialog) where slot 1+ might be GEM-typed by the user."""
+
+    def test_ahdi_gem_cap_regardless_of_slot(self):
+        # User picks GEM on any slot -> GEM cap (16 strict, 32 perm).
+        for ident in (b"GEM", "GEM"):
+            with self.subTest(ident=ident):
+                self.assertEqual(
+                    atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, True, ident),
+                    16)
+                self.assertEqual(
+                    atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, ident),
+                    32)
+
+    def test_ahdi_bgm_cap_regardless_of_slot(self):
+        # User picks BGM -> BGM cap (256 strict, 512 perm).
+        for ident in (b"BGM", "BGM"):
+            with self.subTest(ident=ident):
+                self.assertEqual(
+                    atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, True, ident),
+                    256)
+                self.assertEqual(
+                    atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, ident),
+                    512)
+
+    def test_unknown_ahdi_ident_falls_back_to_bgm_cap(self):
+        # Defensive: anything other than GEM uses the BGM cap.
+        self.assertEqual(
+            atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, b"XGM"),
+            512)
+        self.assertEqual(
+            atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, None),
+            512)
+
+    def test_hybrid_ignores_ident(self):
+        # PPDRIVER / HDDRIVER use the FAT16 ceiling regardless.
+        for fmt in (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER):
+            for ident in (b"GEM", b"BGM", None, "FAT16"):
+                with self.subTest(format=fmt, ident=ident):
+                    self.assertEqual(
+                        atari_hd.cap_mb_for_type(fmt, False, ident),
+                        atari_hd.MAX_PARTITION_MB)
+                    self.assertEqual(
+                        atari_hd.cap_mb_for_type(fmt, True, ident),
+                        atari_hd.MAX_PARTITION_MB)
+
+
 class TestAhdiPartitionId(unittest.TestCase):
     """ahdi_partition_id picks the ident bytes (b'GEM' / b'BGM')."""
 

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -204,17 +204,21 @@ class TestPartitionLayout(unittest.TestCase):
             14: (3, True, 11),
         },
         atari_hd.FORMAT_PPDRIVER: {
-            # PPTOSDOS convention: one primary + extended chain.
-            # Multi-primary PPDRIVER fails on real Atari hardware at
-            # >256 MB partition sizes (empirically verified), and the
-            # single-primary layout is what real PPDRIVER tools emit.
+            # PPTOSDOS allows up to 4 primaries (each individually
+            # capped at HYBRID_PRIMARY_MAX_MB = 255 MB so its TOS bps
+            # stays <= 4096); N > 4 falls to (cap-1) primaries plus an
+            # MBR extended container holding the rest as logicals.
+            # The earlier "single-primary" iteration of this rule came
+            # from misdiagnosing a 2 x 511 MB hardware failure that
+            # actually traced to bps>4096-in-primary, not multi-primary
+            # itself.
             1:  (1, False, 0),
-            2:  (1, True, 1),
-            3:  (1, True, 2),
-            4:  (1, True, 3),
-            5:  (1, True, 4),
-            10: (1, True, 9),
-            14: (1, True, 13),
+            2:  (2, False, 0),
+            3:  (3, False, 0),
+            4:  (4, False, 0),
+            5:  (3, True, 2),     # MBR P3 becomes ext container
+            10: (3, True, 7),
+            14: (3, True, 11),
         },
         atari_hd.FORMAT_HDDRIVER: {
             1:  (1, False, 0),     # primary cap = 1

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -36,8 +36,11 @@ class TestPartitionCapMb(unittest.TestCase):
             atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, True, 0), 16)
 
     def test_ahdi_permissive_gem_cap(self):
+        # 31 MB, not 32: ident=GEM strictly implies bps=512, and
+        # choose_logical_sector_size flips to bps=1024 at 32 MB.
+        # See AHDI_GEM_MAX_MB rationale in atari_hd.py.
         self.assertEqual(
-            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, False, 0), 32)
+            atari_hd.partition_cap_mb(atari_hd.FORMAT_AHDI, False, 0), 31)
 
     def test_ahdi_strict_bgm_cap(self):
         # Slot 1+ is BGM. Strict caps BGM at 256 MB.
@@ -82,7 +85,8 @@ class TestCapMbForType(unittest.TestCase):
     dialog) where slot 1+ might be GEM-typed by the user."""
 
     def test_ahdi_gem_cap_regardless_of_slot(self):
-        # User picks GEM on any slot -> GEM cap (16 strict, 32 perm).
+        # User picks GEM on any slot -> GEM cap (16 strict, 31 perm).
+        # Perm cap is 31, not 32: ident=GEM strictly implies bps=512.
         for ident in (b"GEM", "GEM"):
             with self.subTest(ident=ident):
                 self.assertEqual(
@@ -90,7 +94,7 @@ class TestCapMbForType(unittest.TestCase):
                     16)
                 self.assertEqual(
                     atari_hd.cap_mb_for_type(atari_hd.FORMAT_AHDI, False, ident),
-                    32)
+                    31)
 
     def test_ahdi_bgm_cap_regardless_of_slot(self):
         # User picks BGM -> BGM cap (256 strict, 511 perm).
@@ -129,36 +133,38 @@ class TestCapMbForType(unittest.TestCase):
 
 
 class TestAhdiPartitionId(unittest.TestCase):
-    """ahdi_partition_id picks the ident bytes (b'GEM' / b'BGM')."""
+    """ahdi_partition_id picks the ident bytes (b'GEM' / b'BGM')
+    strictly from the bps that choose_logical_sector_size picks for
+    the partition's 512-byte sector count.
 
-    def test_first_partition_is_always_gem(self):
-        # Defensive clamp: legacy drivers (original AHDI / SCSI Tools)
-        # required GEM on the boot slot. TOS itself only checks the
-        # boot flag, but emitting GEM at slot 0 is the broadest-
-        # compatibility pick. See atari_hd.ahdi_partition_id() for the
-        # full rationale.
-        for size in (1, 16, 17, 32, 33, 100, 256, 257, 512, 1024):
-            for strict in (True, False):
-                with self.subTest(size=size, strict=strict):
-                    self.assertEqual(
-                        atari_hd.ahdi_partition_id(size, strict,
-                                                    is_first=True),
-                        b"GEM",
-                        f"size={size}, strict={strict} must be GEM")
+    Per AHDI 3.0 / the Atari Compendium: GEM means bps=512, BGM means
+    bps>512. The Hatari doubling rule keeps bps=512 only while
+    clusters_at_spc=2 stays <= 32765, i.e. partition_sec_512 <= 65530
+    (~31.99 MB). At 32 MB exactly the rule doubles to bps=1024.
 
-    def test_permissive_threshold_at_32mb(self):
-        # TOS 1.04+ uses a 32 MB threshold for non-first slots.
-        self.assertEqual(
-            atari_hd.ahdi_partition_id(32, False, is_first=False), b"GEM")
-        self.assertEqual(
-            atari_hd.ahdi_partition_id(33, False, is_first=False), b"BGM")
+    The earlier version of this function accepted an `is_first` flag
+    that forced GEM at slot 0 regardless of size; that force was
+    removed because it could produce GEM+bps=1024, which the
+    Compendium flagged as malformed (legacy drivers may corrupt past
+    the first 32 MB of physical sectors). Slot 0 is now kept in the
+    GEM region by partition_cap_mb() instead, so the ident landing
+    here is always consistent with the BPB."""
 
-    def test_strict_threshold_at_16mb(self):
-        # TOS < 1.04 tightens the threshold to 16 MB.
-        self.assertEqual(
-            atari_hd.ahdi_partition_id(16, True, is_first=False), b"GEM")
-        self.assertEqual(
-            atari_hd.ahdi_partition_id(17, True, is_first=False), b"BGM")
+    def test_gem_region(self):
+        # Sizes that choose_logical_sector_size keeps at bps=512 -> GEM.
+        for size in (1, 2, 8, 16, 17, 24, 30, 31):
+            with self.subTest(size=size):
+                self.assertEqual(
+                    atari_hd.ahdi_partition_id(size), b"GEM",
+                    f"{size} MB sits at bps=512; ident must be GEM")
+
+    def test_bgm_region(self):
+        # 32 MB is the first size that trips bps=1024 -> BGM.
+        for size in (32, 33, 64, 128, 256, 511):
+            with self.subTest(size=size):
+                self.assertEqual(
+                    atari_hd.ahdi_partition_id(size), b"BGM",
+                    f"{size} MB sits at bps>512; ident must be BGM")
 
 
 class TestPartitionLayout(unittest.TestCase):
@@ -278,8 +284,8 @@ class TestRejectionPaths(unittest.TestCase):
         self.assertIn("BGM", msg, msg)
 
     def test_ahdi_permissive_first_partition_over_gem_cap(self):
-        # 33 MB > 32 MB permissive GEM cap => reject under TOS 1.04+ mode.
-        partitions = [atari_hd.Partition(name="BOOT", size_mb=33)]
+        # 32 MB > 31 MB permissive GEM cap => reject under TOS 1.04+ mode.
+        partitions = [atari_hd.Partition(name="BOOT", size_mb=32)]
         with self.assertRaises(ValueError) as ctx:
             atari_hd.plan_image(atari_hd.FORMAT_AHDI, "<test>", image_mb=64,
                                 partitions=partitions, strict_tos=False)
@@ -288,9 +294,11 @@ class TestRejectionPaths(unittest.TestCase):
         self.assertIn("boot (GEM)", msg, msg)
 
     def test_ahdi_permissive_bgm_partition_over_cap(self):
-        # 600 MB > 511 MB permissive BGM cap.
+        # 600 MB > 511 MB permissive BGM cap. BOOT is 31 MB (the
+        # permissive GEM cap) so plan_image gets past slot 0 and
+        # reaches the BGM-cap check on slot 1.
         partitions = [
-            atari_hd.Partition(name="BOOT", size_mb=32),
+            atari_hd.Partition(name="BOOT", size_mb=31),
             atari_hd.Partition(name="HUGE", size_mb=600),
         ]
         with self.assertRaises(ValueError) as ctx:

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -63,16 +63,20 @@ class TestPartitionCapMb(unittest.TestCase):
                     atari_hd.partition_cap_mb(
                         atari_hd.FORMAT_AHDI, True, slot), 256)
 
-    def test_hybrid_caps_have_no_per_slot_distinction(self):
-        # PPDRIVER / HDDRIVER go through the DOS view, which doesn't care
-        # about TOS BGM limits. The cap is the hybrid layout ceiling
-        # (511 MB; TOS NSECTS 16-bit max at bps=8192) regardless of
-        # slot or strict flag. The strict flag is meaningless for
-        # hybrids -- they target TOS 1.04+ exclusively (synthesize
-        # rejects ratio < 2 / tos_bps < 1024).
+    def test_hybrid_primary_cap_at_slot_0(self):
+        # PPDRIVER / HDDRIVER both cap the primary slot at
+        # HYBRID_PRIMARY_MAX_MB (255 MB) because real driver behaviour
+        # rejects primaries with bps>4096. Strict flag is meaningless
+        # for hybrids; same cap regardless. Slots 1+ get the full
+        # HYBRID_MAX (511 MB) since the chain-link path supports up
+        # to bps=8192.
         for fmt in (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER):
-            for slot in (0, 1, 5, 13):
-                for strict in (True, False):
+            for strict in (True, False):
+                with self.subTest(format=fmt, slot=0, strict=strict):
+                    self.assertEqual(
+                        atari_hd.partition_cap_mb(fmt, strict, 0),
+                        atari_hd.HYBRID_PRIMARY_MAX_MB)
+                for slot in (1, 5, 13):
                     with self.subTest(format=fmt, slot=slot, strict=strict):
                         self.assertEqual(
                             atari_hd.partition_cap_mb(fmt, strict, slot),
@@ -117,10 +121,9 @@ class TestCapMbForType(unittest.TestCase):
             511)
 
     def test_hybrid_ignores_ident(self):
-        # PPDRIVER / HDDRIVER use the hybrid-layout ceiling regardless
-        # of ident or strict_tos. The cap (511 MB) comes from the TOS
-        # NSECTS 16-bit limit at the maximum supported TOS bps of
-        # 8192 -- not the FAT16 cluster ceiling.
+        # PPDRIVER / HDDRIVER ignore the ident; only slot index matters
+        # for the cap. With slot_index unset (or >= 1) we get the
+        # HYBRID_MAX ceiling. Strict flag is meaningless for hybrids.
         for fmt in (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER):
             for ident in (b"GEM", b"BGM", None, "FAT16"):
                 with self.subTest(format=fmt, ident=ident):
@@ -130,6 +133,24 @@ class TestCapMbForType(unittest.TestCase):
                     self.assertEqual(
                         atari_hd.cap_mb_for_type(fmt, True, ident),
                         atari_hd.HYBRID_MAX_PARTITION_MB)
+                    # Slot 1+ explicitly: still HYBRID_MAX.
+                    self.assertEqual(
+                        atari_hd.cap_mb_for_type(fmt, False, ident,
+                                                  slot_index=1),
+                        atari_hd.HYBRID_MAX_PARTITION_MB)
+
+    def test_hybrid_primary_slot_picks_primary_cap(self):
+        # When slot_index=0 is passed, both hybrids return the
+        # HYBRID_PRIMARY_MAX_MB cap regardless of ident or strict_tos.
+        for fmt in (atari_hd.FORMAT_PPDRIVER, atari_hd.FORMAT_HDDRIVER):
+            for ident in (b"GEM", b"BGM", None, "FAT16"):
+                for strict in (True, False):
+                    with self.subTest(format=fmt, ident=ident,
+                                      strict=strict):
+                        self.assertEqual(
+                            atari_hd.cap_mb_for_type(fmt, strict, ident,
+                                                      slot_index=0),
+                            atari_hd.HYBRID_PRIMARY_MAX_MB)
 
 
 class TestAhdiPartitionId(unittest.TestCase):

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -7,10 +7,13 @@ prevent re-discovering them the hard way.
 
 Covered:
   - partition_cap_mb: AHDI per-slot caps, hybrid no-per-slot caps.
-  - ahdi_partition_id: first slot always GEM; threshold pick for slots 1+.
+  - ahdi_partition_id: first slot always emitted as GEM (defensive
+    legacy-driver-compatibility clamp; not a hard TOS rule -- see
+    atari_hd.ahdi_partition_id() docstring); threshold pick for
+    slots 1+.
   - partition_layout: primary/extended split per format for representative N.
   - Rejection paths: out-of-range N, AHDI strict caps, AHDI permissive caps,
-    HDDRIVER primary cap (always 1), first-AHDI-must-be-GEM invariant.
+    HDDRIVER primary cap (always 1), first-AHDI-always-GEM invariant.
 """
 
 import unittest
@@ -119,8 +122,11 @@ class TestAhdiPartitionId(unittest.TestCase):
     """ahdi_partition_id picks the ident bytes (b'GEM' / b'BGM')."""
 
     def test_first_partition_is_always_gem(self):
-        # Hard rule: TOS only boots from a GEM entry, so slot 0 must be
-        # GEM regardless of size or strict mode.
+        # Defensive clamp: legacy drivers (original AHDI / SCSI Tools)
+        # required GEM on the boot slot. TOS itself only checks the
+        # boot flag, but emitting GEM at slot 0 is the broadest-
+        # compatibility pick. See atari_hd.ahdi_partition_id() for the
+        # full rationale.
         for size in (1, 16, 17, 32, 33, 100, 256, 257, 512, 1024):
             for strict in (True, False):
                 with self.subTest(size=size, strict=strict):

--- a/scripts/atari-hd/tests/test_caps.py
+++ b/scripts/atari-hd/tests/test_caps.py
@@ -177,13 +177,17 @@ class TestPartitionLayout(unittest.TestCase):
             14: (3, True, 11),
         },
         atari_hd.FORMAT_PPDRIVER: {
+            # PPTOSDOS convention: one primary + extended chain.
+            # Multi-primary PPDRIVER fails on real Atari hardware at
+            # >256 MB partition sizes (empirically verified), and the
+            # single-primary layout is what real PPDRIVER tools emit.
             1:  (1, False, 0),
-            2:  (2, False, 0),
-            3:  (3, False, 0),
-            4:  (4, False, 0),
-            5:  (3, True, 2),     # MBR P3 becomes ext container
-            10: (3, True, 7),
-            14: (3, True, 11),
+            2:  (1, True, 1),
+            3:  (1, True, 2),
+            4:  (1, True, 3),
+            5:  (1, True, 4),
+            10: (1, True, 9),
+            14: (1, True, 13),
         },
         atari_hd.FORMAT_HDDRIVER: {
             1:  (1, False, 0),     # primary cap = 1

--- a/scripts/atari-hd/tests/test_dual_bpb.py
+++ b/scripts/atari-hd/tests/test_dual_bpb.py
@@ -67,17 +67,30 @@ class TestDualBpbInvariants(unittest.TestCase):
         # The hybrid PRIMARY cap is HYBRID_PRIMARY_MAX_MB (255 MB):
         # real PPDRIVER / HDDRIVER reject primaries with bps>4096.
         # When the test fixture wants a partition larger than that,
-        # put a small dummy primary first and place the test partition
-        # in slot 1 (logical, in the extended chain) so plan_image
-        # accepts it.
+        # we need to place it in the extended chain. PPDRIVER allows
+        # up to 4 primaries (with the per-primary 255 MB cap) and
+        # only spills to the extended chain at N >= 5; HDDRIVER caps
+        # primaries at 1 and spills at N >= 2. To exercise the
+        # extended chain on either format the test pads with the
+        # right number of small dummy primaries first, then places
+        # the test partition at slot=primary_count.
+        # Per-partition is_extended: the test partition must be
+        # extended (is_extended=True) when its size exceeds the
+        # hybrid primary cap, so it lands at bps=8192 in the chain.
+        # Pad with a single small primary at slot 0 to satisfy the
+        # "first slot must be primary" rule -- one is enough now
+        # that PPDRIVER allows the second slot onwards to be
+        # extended directly without having to fill all 4 primary
+        # slots first.
         if size_mb > atari_hd.HYBRID_PRIMARY_MAX_MB:
+            min_p = atari_hd.HYBRID_MIN_PARTITION_MB
             partitions = [
-                atari_hd.Partition(name="BOOT",
-                                    size_mb=atari_hd.HYBRID_MIN_PARTITION_MB),
-                atari_hd.Partition(name="P", size_mb=size_mb),
+                atari_hd.Partition(name="BOOT", size_mb=min_p),
+                atari_hd.Partition(name="P", size_mb=size_mb,
+                                    is_extended=True),
             ]
             test_slot = 1
-            image_mb = size_mb + atari_hd.HYBRID_MIN_PARTITION_MB + 4
+            image_mb = size_mb + min_p + 4
         else:
             partitions = [atari_hd.Partition(name="P", size_mb=size_mb)]
             test_slot = 0

--- a/scripts/atari-hd/tests/test_dual_bpb.py
+++ b/scripts/atari-hd/tests/test_dual_bpb.py
@@ -64,15 +64,31 @@ class TestDualBpbInvariants(unittest.TestCase):
                         self._check_one(tmp, fmt, ratio, size_mb)
 
     def _check_one(self, tmp, fmt, ratio, size_mb):
-        partitions = [atari_hd.Partition(name="P", size_mb=size_mb)]
+        # The hybrid PRIMARY cap is HYBRID_PRIMARY_MAX_MB (255 MB):
+        # real PPDRIVER / HDDRIVER reject primaries with bps>4096.
+        # When the test fixture wants a partition larger than that,
+        # put a small dummy primary first and place the test partition
+        # in slot 1 (logical, in the extended chain) so plan_image
+        # accepts it.
+        if size_mb > atari_hd.HYBRID_PRIMARY_MAX_MB:
+            partitions = [
+                atari_hd.Partition(name="BOOT",
+                                    size_mb=atari_hd.HYBRID_MIN_PARTITION_MB),
+                atari_hd.Partition(name="P", size_mb=size_mb),
+            ]
+            test_slot = 1
+            image_mb = size_mb + atari_hd.HYBRID_MIN_PARTITION_MB + 4
+        else:
+            partitions = [atari_hd.Partition(name="P", size_mb=size_mb)]
+            test_slot = 0
+            image_mb = size_mb + 4
         plan = atari_hd.plan_image(
             fmt, image_path="<placeholder>",
-            image_mb=size_mb + 4,  # leave a small tail for partition table
-            partitions=partitions, strict_tos=False)
+            image_mb=image_mb, partitions=partitions, strict_tos=False)
 
         # Verify the geometry chose the ratio we expected. If not, the
         # rest of the test is meaningless.
-        actual_ratio = plan.partitions[0].tos_bps // 512
+        actual_ratio = plan.partitions[test_slot].tos_bps // 512
         self.assertEqual(
             actual_ratio, ratio,
             f"format={fmt} size={size_mb} MB: planner chose "
@@ -85,7 +101,7 @@ class TestDualBpbInvariants(unittest.TestCase):
         # Read DOS BPB at start_lba and TOS BPB at start_lba + 1.
         # Both BPBs are 512-byte structures regardless of the declared
         # bytes_per_sector; parse_bpb is sector-size-agnostic.
-        first_lba = plan.partitions[0].start_lba
+        first_lba = plan.partitions[test_slot].start_lba
         with open(path, "rb") as f:
             f.seek(first_lba * 512)
             dos_buf = f.read(512)

--- a/scripts/atari-hd/tests/test_partition_tables.py
+++ b/scripts/atari-hd/tests/test_partition_tables.py
@@ -116,8 +116,12 @@ class TestAhdiRoot(unittest.TestCase):
                                  "the 0x55AA MBR signature")
 
     def test_four_primaries_mixed_gem_bgm(self):
-        # Slot 0 is forced to GEM regardless of size; slots 1+ pick GEM/BGM
-        # from the size threshold (32 MB by default).
+        # Idents follow bps strictly: GEM iff bps=512 (size <= 31 MB),
+        # BGM iff bps>512 (size >= 32 MB). 32 MB is the first size that
+        # trips the doubling rule, so S1 is BGM, not GEM (the earlier
+        # version of this test expected GEM at 32 MB; that combination
+        # was technically malformed -- ident=GEM with bps=1024 -- and
+        # was flagged by the AHDI 3.0 review).
         partitions = [
             _make_partition("BOOT", size_mb=16, size_sectors=32768,  start_lba=2),
             _make_partition("S1",   size_mb=32, size_sectors=65536,  start_lba=32770),
@@ -128,7 +132,7 @@ class TestAhdiRoot(unittest.TestCase):
         sec = atari_hd.build_root_sector_ahdi(plan)
         slots = parse_ahdi_root(sec)
 
-        expected_idents = [b"GEM", b"GEM", b"BGM", b"BGM"]
+        expected_idents = [b"GEM", b"BGM", b"BGM", b"BGM"]
         for i, (part, want_ident) in enumerate(zip(partitions, expected_idents)):
             raw = sec[AHDI_SLOT_OFFSETS[i]:AHDI_SLOT_OFFSETS[i] + 12]
             with self.subTest(slot=i, partition=part.name):

--- a/scripts/atari-hd/tests/test_partition_tables.py
+++ b/scripts/atari-hd/tests/test_partition_tables.py
@@ -34,7 +34,10 @@ AHDI_EXISTS_BOOT = 0x81
 
 # MBR partition types
 MBR_TYPE_FAT16 = 0x06
-MBR_TYPE_EXTENDED = 0x0F
+MBR_TYPE_EXTENDED_LBA = 0x0F   # PPDRIVER's container marker
+MBR_TYPE_EXTENDED_CHS = 0x05   # HDDRIVER's container marker
+# Backward-compat alias used by the PPDRIVER-side tests in this module.
+MBR_TYPE_EXTENDED = MBR_TYPE_EXTENDED_LBA
 
 
 def _make_partition(name, size_mb, size_sectors, start_lba,
@@ -376,8 +379,11 @@ class TestHddriverRoot(unittest.TestCase):
         mbr = parse_mbr_root(sec)
 
         # P0 unchanged, P1 = extended container.
+        # HDDRIVER uses CHS-extended FAT16B (0x05), NOT the LBA variant
+        # PPDRIVER uses (0x0F) -- per the Atari Compendium, this byte
+        # mirrors what real HDDRIVER images ship with.
         self.assertEqual(mbr["slots"][0]["part_type"], MBR_TYPE_FAT16)
-        self.assertEqual(mbr["slots"][1]["part_type"], MBR_TYPE_EXTENDED)
+        self.assertEqual(mbr["slots"][1]["part_type"], MBR_TYPE_EXTENDED_CHS)
         self.assertEqual(mbr["slots"][1]["rel_start_lba"], log0.ebr_lba)
         self.assertEqual(mbr["slots"][1]["sector_count"],
                          (log0.start_lba + log0.size_sectors) - log0.ebr_lba)

--- a/scripts/atari-hd/tests/test_round_trip.py
+++ b/scripts/atari-hd/tests/test_round_trip.py
@@ -71,11 +71,15 @@ class TestRoundTrip(unittest.TestCase):
                                  f"slot {i} ident")
 
     def test_ppdriver_ebr_chain(self):
-        # 5 partitions => 3 primary + 2 logicals via MBR extended chain.
-        # PPDRIVER hybrid requires partitions large enough for tos_bps
-        # to be >=1024; 32 MB is the smallest size that satisfies that.
+        # 5 partitions: 3 primary (slots 0..2) + 2 extended (slots 3..4).
+        # The user picks primary vs extended per partition via
+        # Partition.is_extended; this fixture mirrors what a typical
+        # multi-primary PPDRIVER layout looks like (max 4 primaries on
+        # PPDRIVER; here we use 3 + 2 to exercise both halves of the
+        # writer). 32 MB is the smallest size that hits tos_bps>=1024.
         partitions = [
-            atari_hd.Partition(name=f"P{i + 1}", size_mb=32)
+            atari_hd.Partition(name=f"P{i + 1}", size_mb=32,
+                                is_extended=(i >= 3))
             for i in range(5)
         ]
         plan = atari_hd.plan_image(
@@ -97,12 +101,12 @@ class TestRoundTrip(unittest.TestCase):
                                  f"slot {i} part_type")
 
     def test_hddriver_ebr_chain(self):
-        # 2 partitions => 1 primary + 1 logical via the MBR extended
-        # chain. HDDRIVER's primary cap is 1, so any N>=2 hits the
-        # extended path. 32 MB partitions for the same hybrid reason.
+        # 2 partitions: 1 primary + 1 extended. HDDRIVER's primary cap
+        # is 1, so the second partition MUST be is_extended=True.
+        # 32 MB partitions for the same hybrid (tos_bps>=1024) reason.
         partitions = [
             atari_hd.Partition(name="BOOT", size_mb=32),
-            atari_hd.Partition(name="DATA", size_mb=32),
+            atari_hd.Partition(name="DATA", size_mb=32, is_extended=True),
         ]
         plan = atari_hd.plan_image(
             atari_hd.FORMAT_HDDRIVER, image_path="<placeholder>",

--- a/scripts/atari-hd/tui/DECISIONS.md
+++ b/scripts/atari-hd/tui/DECISIONS.md
@@ -1,0 +1,92 @@
+# TUI design decisions
+
+This document records the load-bearing decisions made for the
+`scripts/atari-hd/tui/` package. Update it (don't replace it) when a
+later story changes course; keep the history readable.
+
+## 1. Framework: plain ANSI escapes
+
+**Chosen.** All TUI output is plain ANSI escape sequences written
+directly to `stdout`; all input is raw bytes read from `stdin`. The
+package does its own raw-mode entry/exit, key parsing, and screen
+redraw.
+
+**Discarded:**
+- *Stdlib `curses`* — works on Linux / macOS but on Windows requires
+  the third-party `windows-curses` package from PyPI. That breaks the
+  zero-deps stance the rest of this project guards (no `pip install`
+  anywhere). Acceptable only with an explicit Windows exception, which
+  this project does not have.
+- *Third-party (`prompt_toolkit`, `urwid`, `textual`)* — best UX, but
+  hard no on the dependency front. Same reason.
+
+**Tradeoff accepted:** more code (raw mode, key decoding, alt-screen
+management, redraw on resize) in exchange for genuine zero-deps on all
+three target OSes.
+
+## 2. Cross-platform notes
+
+- **Unix (Linux / macOS):** `termios` + `tty` enter raw mode;
+  `select` peeks for pending input when disambiguating ESC vs.
+  ESC-sequence; `os.read(stdin, 1)` for byte-level reads.
+- **Windows 10+:** `kernel32.SetConsoleMode` toggles
+  `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on stdout (so ANSI sequences
+  render) and `ENABLE_VIRTUAL_TERMINAL_INPUT` on stdin (so the
+  console emits ANSI escape sequences for arrows etc., matching
+  Unix); `msvcrt.getch` reads bytes one at a time. Old `cmd.exe`
+  pre-Windows-10 is **not supported** — Windows Terminal / modern
+  PowerShell are the baseline.
+- **Terminal restoration is mandatory.** All raw-mode and
+  alt-screen state is wrapped in a `contextmanager` whose `finally`
+  branch fires on `KeyboardInterrupt` and unhandled exceptions. A
+  crash that leaves the user without echo / cursor / normal screen
+  is the worst-case TUI bug; the context manager is the only line of
+  defense.
+- **Minimum terminal size: 80×24.** Enforced by story 002 (the main
+  screen layout). Below that, the TUI shows "terminal too small" and
+  refuses to proceed. v1 does not graceful-degrade.
+
+## 3. State management: single `@dataclass`, no globals
+
+All TUI state lives in one `State` dataclass (`state.py`). The event
+loop owns the only instance; screens read from it and return a
+mutated copy (or mutate in place — either is fine, but no globals).
+
+**Rendering is a pure function** of state: `render(state) -> frame
+string`. The event loop writes the frame to stdout on a dirty flag.
+This is the simplest model that lets us test rendering without a
+terminal: future stories can call `render(state)` from a unittest and
+assert on the returned string.
+
+## 4. Event loop
+
+A single `while not state.exit_requested` loop in `app.py`:
+
+```python
+with terminal_session():
+    while not state.exit_requested:
+        if state.dirty:
+            stdout.write(render(state))
+            stdout.flush()
+            state.dirty = False
+        key = read_key()
+        state = handle_key(state, key)
+```
+
+`read_key()` blocks until a single key (or known escape sequence) is
+ready. `handle_key()` dispatches based on the current screen. No
+threads, no async, no signal handlers — keep the model boring so
+debugging on a misbehaving terminal is straightforward.
+
+## Deferred to later stories
+
+The following design questions are deliberately left open here; each
+story records its decision in this document when it lands.
+
+- **TTY detection + `--no-tui` fallback** — story 009.
+- **Partition editing model** (modal dialog / wizard / inline edit)
+  — story 004.
+- **Commit step** (single Write action vs. auto-save) — story 006.
+- **Validators for caps / GEM-first / etc.** — must stay as pure
+  functions in `atari_hd.py`; the TUI never re-implements rules.
+  Locked by epic-002 / story 004 tests.

--- a/scripts/atari-hd/tui/DECISIONS.md
+++ b/scripts/atari-hd/tui/DECISIONS.md
@@ -45,6 +45,13 @@ three target OSes.
 - **Minimum terminal size: 80×24.** Enforced by story 002 (the main
   screen layout). Below that, the TUI shows "terminal too small" and
   refuses to proceed. v1 does not graceful-degrade.
+- **Resize redraw — POSIX yes, Windows on next keypress.** Story 002
+  installs a `SIGWINCH` handler on POSIX that surfaces a synthetic
+  `Key.RESIZE` to the event loop, triggering an immediate redraw at
+  the new size. Windows has no `SIGWINCH` equivalent and adding a
+  polling thread would violate the "no threads / no async" guideline,
+  so on Windows the layout updates on the next keypress instead.
+  Acceptable v1 behavior; revisit if it bites.
 
 ## 3. State management: single `@dataclass`, no globals
 

--- a/scripts/atari-hd/tui/DECISIONS.md
+++ b/scripts/atari-hd/tui/DECISIONS.md
@@ -85,6 +85,19 @@ ready. `handle_key()` dispatches based on the current screen. No
 threads, no async, no signal handlers — keep the model boring so
 debugging on a misbehaving terminal is straightforward.
 
+## 5. List navigation: hard-stop at bounds (no wrap)
+
+**Chosen.** Up / Down arrows (and `j` / `k`) move the highlighted row
+in the partition list, but selection does **not** wrap from the last
+row to the first. At the bounds the keypress is silently ignored.
+
+**Rationale:** partition lists are short (≤14 rows); wrapping is more
+likely to surprise the user than to help them. Every list this epic
+introduces (partition list in story 003, future format chooser in
+005, etc.) follows this rule for consistency -- if a user learns
+that pressing Up at row 0 does nothing, they don't have to relearn
+the convention elsewhere in the TUI.
+
 ## Deferred to later stories
 
 The following design questions are deliberately left open here; each

--- a/scripts/atari-hd/tui/__init__.py
+++ b/scripts/atari-hd/tui/__init__.py
@@ -1,0 +1,10 @@
+"""Cross-platform terminal user interface for atari_hd.py.
+
+Plain ANSI escape sequences only -- no curses, no third-party libs.
+See DECISIONS.md for the framework choice and rationale.
+
+Story 001 lands the skeleton: terminal session manager, key reader,
+state dataclass, render function, and a placeholder screen. Real
+screens (partition list, edit dialog, format selector, commit flow,
+load existing image) come in stories 002-008.
+"""

--- a/scripts/atari-hd/tui/__main__.py
+++ b/scripts/atari-hd/tui/__main__.py
@@ -1,0 +1,26 @@
+"""Entry point for the atari-hd TUI.
+
+Runnable two ways:
+
+    python scripts/atari-hd/tui            # directory invocation
+    cd scripts/atari-hd && python -m tui   # package invocation
+
+Directory invocation runs this file as a top-level script with no
+package context, so a `from .app import main` would fail. We inject
+the package's parent directory onto sys.path and use an absolute
+import; that works for both invocation styles.
+"""
+
+import os
+import sys
+
+
+_PARENT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+from tui.app import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -39,6 +39,22 @@ def handle_key(state: State, key) -> State:
         state.dirty = True
         return state
 
+    # Help overlay (story 008): when open, swallow input until the
+    # user closes it via Esc or `?` again. Layered above every other
+    # handler so any underlying screen / dialog / prompt is preserved
+    # exactly as it was when the user opened help.
+    if state.show_help:
+        return _handle_help_open(state, key)
+    # `?` opens help from any screen, including inside dialogs and
+    # prompts. We accept it as a global shortcut even if it would
+    # otherwise be a printable char in a text-entry prompt; users
+    # rarely need a literal `?` in image filenames, and the spec
+    # requires a single consistent help key.
+    if isinstance(key, str) and key == "?":
+        state.show_help = True
+        state.dirty = True
+        return state
+
     # Modal edit dialog takes precedence over every other handler.
     if state.edit_dialog is not None:
         return _handle_edit_dialog(state, key)
@@ -64,6 +80,26 @@ def handle_key(state: State, key) -> State:
         return _handle_discard_unsaved_confirm(state, key)
     if state.prompt_mode == PromptMode.CONFIRM_DISCARD_BEFORE_LOAD:
         return _handle_discard_before_load_confirm(state, key)
+    return state
+
+
+# -------------------------------------------------------------------
+# Help overlay (story 008)
+# -------------------------------------------------------------------
+
+def _handle_help_open(state: State, key) -> State:
+    """While the help overlay is up: Esc / `?` close it, Ctrl-C still
+    exits (consistent with everywhere), all other keys are ignored.
+    Underlying state (edit_dialog / prompt_mode / partition selection)
+    is never touched, so closing the overlay returns the user exactly
+    where they were."""
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    if key == Key.ESC or (isinstance(key, str) and key == "?"):
+        state.show_help = False
+        state.dirty = True
+        return state
     return state
 
 

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -48,6 +48,12 @@ def handle_key(state: State, key) -> State:
         return _handle_overwrite_confirm(state, key)
     if state.prompt_mode == PromptMode.CONFIRM_DELETE:
         return _handle_delete_confirm(state, key)
+    if state.prompt_mode == PromptMode.ASK_FORMAT:
+        return _handle_ask_format(state, key)
+    if state.prompt_mode == PromptMode.ASK_STRICT_TOS:
+        return _handle_ask_strict_tos(state, key)
+    if state.prompt_mode == PromptMode.CONFIRM_DROP_PARTITIONS:
+        return _handle_drop_confirm(state, key)
     return state
 
 
@@ -130,6 +136,8 @@ def _handle_partition_action(state: State, k: str) -> State:
         return _open_edit_dialog(state)
     if k == "t":
         return _toggle_type_inline(state)
+    if k == "f":
+        return _open_format_chooser(state)
     if k == "w":
         # Real handler lands in story 006.
         if _has_real_partitions(state):
@@ -273,6 +281,148 @@ def _handle_delete_confirm(state: State, key) -> State:
     state.status_message = "delete cancelled"
     state.dirty = True
     return state
+
+
+# -------------------------------------------------------------------
+# F: format selector + AHDI strict-TOS toggle (story 005)
+# -------------------------------------------------------------------
+
+def _open_format_chooser(state: State) -> State:
+    state.prompt_mode = PromptMode.ASK_FORMAT
+    state.status_message = None
+    state.dirty = True
+    return state
+
+
+def _handle_ask_format(state: State, key) -> State:
+    if key == Key.ESC:
+        _reset_format_pending(state)
+        state.dirty = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    if not isinstance(key, str):
+        return state
+    chosen = {"a": "AHDI", "p": "PPDRIVER", "h": "HDDRIVER"}.get(key.lower())
+    if chosen is None:
+        return state
+    state.pending_format = chosen
+    if chosen == "AHDI":
+        # Need the strict-TOS answer before we can revalidate.
+        state.prompt_mode = PromptMode.ASK_STRICT_TOS
+        state.dirty = True
+        return state
+    # Hybrid formats don't honor strict_tos.
+    state.pending_strict_tos = False
+    return _resolve_pending_format(state)
+
+
+def _handle_ask_strict_tos(state: State, key) -> State:
+    if key == Key.ESC:
+        _reset_format_pending(state)
+        state.dirty = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    # y -> strict on; anything else (including N, Enter, others) -> off.
+    state.pending_strict_tos = (
+        isinstance(key, str) and key.lower() == "y")
+    return _resolve_pending_format(state)
+
+
+def _resolve_pending_format(state: State) -> State:
+    """We have pending_format and pending_strict_tos. Compute which
+    existing partitions would violate the new caps; if any, ask for
+    confirmation before dropping. If none, apply directly."""
+    violators = _find_violator_slots(state, state.pending_format,
+                                      state.pending_strict_tos)
+    if not violators:
+        _apply_pending_format(state, drop_slots=())
+        return state
+    state.pending_drop_slots = violators
+    state.prompt_mode = PromptMode.CONFIRM_DROP_PARTITIONS
+    state.dirty = True
+    return state
+
+
+def _handle_drop_confirm(state: State, key) -> State:
+    if isinstance(key, str) and key.lower() == "y":
+        _apply_pending_format(state, drop_slots=state.pending_drop_slots or ())
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    # Anything else cancels the format change entirely (no partitions
+    # dropped; format unchanged).
+    fmt = state.pending_format
+    _reset_format_pending(state)
+    state.status_message = f"format change to {fmt} cancelled"
+    state.dirty = True
+    return state
+
+
+def _apply_pending_format(state: State, drop_slots) -> State:
+    new_format = state.pending_format
+    new_strict = state.pending_strict_tos or False
+    for slot in drop_slots:
+        if 0 <= slot < len(state.partitions):
+            state.partitions[slot] = None
+    state.format_id = new_format
+    state.strict_tos = new_strict
+    msg = f"format -> {new_format}"
+    if new_format == "AHDI":
+        msg += f" (TOS<1.04: {'on' if new_strict else 'off'})"
+    if drop_slots:
+        msg += f"; dropped {len(drop_slots)} partition(s)"
+    _reset_format_pending(state)
+    state.status_message = msg
+    state.dirty = True
+    return state
+
+
+def _reset_format_pending(state: State) -> None:
+    state.prompt_mode = PromptMode.OFF
+    state.pending_format = None
+    state.pending_strict_tos = None
+    state.pending_drop_slots = None
+
+
+def _find_violator_slots(state: State, candidate_format: str,
+                         candidate_strict: bool):
+    """Return a list of slot indices whose existing partition would
+    exceed the candidate format's per-type cap. Empty list means the
+    format change is cap-safe."""
+    violators = []
+    for i, part in enumerate(state.partitions):
+        if part is None:
+            continue
+        ident = _effective_ident(state, i, part, candidate_format)
+        cap = atari_hd.cap_mb_for_type(candidate_format, candidate_strict,
+                                        ident)
+        if part.size_mb > cap:
+            violators.append(i)
+    return violators
+
+
+def _effective_ident(state: State, slot: int, part, format_id: str) -> str:
+    """The ident the new format would assign this partition. AHDI
+    slot 0 is forced GEM; later AHDI slots honor an existing
+    ahdi_ident if set, else auto-pick by the GEM threshold (slot
+    threshold uses the *candidate* strict_tos, not the current state,
+    so the violation check is honest about the new regime)."""
+    if format_id != "AHDI":
+        return "FAT16"
+    if slot == 0:
+        return "GEM"
+    explicit = getattr(part, "ahdi_ident", None)
+    if explicit in ("GEM", "BGM", b"GEM", b"BGM"):
+        return explicit if isinstance(explicit, str) else explicit.decode()
+    threshold = (atari_hd.AHDI_GEM_MAX_MB_STRICT
+                 if state.pending_strict_tos
+                 else atari_hd.AHDI_GEM_MAX_MB)
+    return "GEM" if part.size_mb <= threshold else "BGM"
 
 
 # -------------------------------------------------------------------

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -5,17 +5,25 @@ flag, repeat until exit_requested. No threads, no async, no signal
 handlers in this module (terminal.py owns SIGWINCH). See DECISIONS.md
 sections 3 and 4.
 
-Story 002 introduces inline-prompt sub-modes routed through their own
-dispatchers; the main-screen handler dispatches N / L / Q.
+Story 004 introduces the modal Add/Edit dialog and the inline Delete
+confirm prompt; the main-screen handler dispatches A / D / E / T to
+those, and W remains a story-006 stub.
 """
 
-import os
 import sys
 
+import atari_hd
+
 from .input import Key, read_key
-from .render import render
-from .state import PromptMode, State
+from .render import is_legal_label_char, validate_edit_dialog
+from .state import (EditDialogState, EditField, EditMode, PromptMode,
+                    State)
 from .terminal import terminal_session
+
+
+# Cap defined by atari_hd.MAX_PARTITIONS for any format; all three
+# share the same TOS drive-letter ceiling (14).
+MAX_PARTITIONS = 14
 
 
 def handle_key(state: State, key) -> State:
@@ -27,6 +35,10 @@ def handle_key(state: State, key) -> State:
         state.dirty = True
         return state
 
+    # Modal edit dialog takes precedence over every other handler.
+    if state.edit_dialog is not None:
+        return _handle_edit_dialog(state, key)
+
     if state.prompt_mode == PromptMode.OFF:
         return _handle_main(state, key)
     if state.prompt_mode in (PromptMode.ASK_NEW_PATH,
@@ -34,6 +46,8 @@ def handle_key(state: State, key) -> State:
         return _handle_text_prompt(state, key)
     if state.prompt_mode == PromptMode.CONFIRM_OVERWRITE:
         return _handle_overwrite_confirm(state, key)
+    if state.prompt_mode == PromptMode.CONFIRM_DELETE:
+        return _handle_delete_confirm(state, key)
     return state
 
 
@@ -48,9 +62,7 @@ def _handle_main(state: State, key) -> State:
         state.exit_requested = True
         return state
 
-    # Navigation in the partition list. Hard-stop at top/bottom (no
-    # wrap) -- DECISIONS.md records the choice for consistency across
-    # every list in this epic.
+    # Navigation in the partition list. Hard-stop at top/bottom.
     if key in (Key.UP, Key.DOWN) or (isinstance(key, str)
                                      and key in ("k", "j")):
         return _handle_navigation(state, key)
@@ -64,9 +76,7 @@ def _handle_main(state: State, key) -> State:
 
     # File-management actions are only available before an image is
     # loaded; once the user has an image, the keybindings switch to
-    # partition operations. Partition actions are stubs in this story
-    # -- story 004 (A/D/E/T) and story 006 (W) replace them with
-    # real handlers.
+    # partition operations.
     if state.image_path is None:
         if k == "n":
             state.prompt_mode = PromptMode.ASK_NEW_PATH
@@ -80,12 +90,12 @@ def _handle_main(state: State, key) -> State:
             state.dirty = True
         return state
 
-    return _handle_partition_action_stub(state, k)
+    return _handle_partition_action(state, k)
 
 
 def _handle_navigation(state: State, key) -> State:
-    """Move selected_slot up/down in the partition list. Hard-stop at
-    bounds; ignored when the list is empty."""
+    """Move selected_slot up/down. Hard-stop at bounds; ignored when
+    the list is empty."""
     if not state.partitions:
         return state
     if key == Key.UP or key == "k":
@@ -99,30 +109,320 @@ def _handle_navigation(state: State, key) -> State:
     return state
 
 
-# Stubs surfaced for the partition-action keys until the real handlers
-# land (A/D/E/T in story 004, W in story 006). Status_message gives the
-# user feedback so we don't leave the screen looking dead.
-_STUB_MESSAGES = {
-    "a": "story 004 implements Add",
-    "d": "story 004 implements Delete",
-    "e": "story 004 implements Edit",
-    "t": "story 004 implements Type toggle",
-    "w": "story 006 implements Write",
-}
+def _has_real_partitions(state: State) -> bool:
+    return any(p is not None for p in state.partitions)
 
 
-def _handle_partition_action_stub(state: State, k: str) -> State:
-    if k not in _STUB_MESSAGES:
+def _selected_is_real(state: State) -> bool:
+    if not state.partitions:
+        return False
+    if not 0 <= state.selected_slot < len(state.partitions):
+        return False
+    return state.partitions[state.selected_slot] is not None
+
+
+def _handle_partition_action(state: State, k: str) -> State:
+    if k == "a":
+        return _open_add_dialog(state)
+    if k == "d":
+        return _open_delete_confirm(state)
+    if k == "e":
+        return _open_edit_dialog(state)
+    if k == "t":
+        return _toggle_type_inline(state)
+    if k == "w":
+        # Real handler lands in story 006.
+        if _has_real_partitions(state):
+            state.status_message = "story 006 implements Write"
+            state.dirty = True
         return state
-    # D / E / T / W require a non-empty list; A is always available
-    # (until 14-cap, which story 004 enforces). Match the dim/enable
-    # rule from the keybinding row.
-    requires_partition = k in ("d", "e", "t", "w")
-    if requires_partition and not state.partitions:
+    return state
+
+
+# -------------------------------------------------------------------
+# A: open add dialog at first hole or append slot
+# -------------------------------------------------------------------
+
+def _next_free_slot(state: State):
+    for i, p in enumerate(state.partitions):
+        if p is None:
+            return i
+    if len(state.partitions) >= MAX_PARTITIONS:
+        return None
+    return len(state.partitions)
+
+
+def _open_add_dialog(state: State) -> State:
+    slot = _next_free_slot(state)
+    if slot is None:
+        state.status_message = (
+            f"partition cap reached ({MAX_PARTITIONS} max)")
+        state.dirty = True
         return state
-    state.status_message = _STUB_MESSAGES[k]
+    is_first = (slot == 0)
+    type_choice = "GEM" if state.format_id != "AHDI" or is_first else "BGM"
+    if state.format_id != "AHDI":
+        type_choice = "GEM"  # arbitrary; ignored for hybrid formats
+    state.edit_dialog = EditDialogState(
+        mode=EditMode.ADD, slot=slot, field=EditField.SIZE,
+        size_buffer="", type_choice=type_choice, label_buffer="")
+    state.status_message = None
     state.dirty = True
     return state
+
+
+# -------------------------------------------------------------------
+# E: open edit dialog on selected partition (must be non-empty)
+# -------------------------------------------------------------------
+
+def _open_edit_dialog(state: State) -> State:
+    if not _selected_is_real(state):
+        return state
+    slot = state.selected_slot
+    part = state.partitions[slot]
+    # Initial type_choice from the existing partition's stored ident
+    # (set at creation time below) or fall back to the auto-pick.
+    ident = getattr(part, "ahdi_ident", None) or _auto_ident(state, slot,
+                                                              part.size_mb)
+    state.edit_dialog = EditDialogState(
+        mode=EditMode.EDIT, slot=slot, field=EditField.SIZE,
+        size_buffer=str(part.size_mb),
+        type_choice=ident,
+        label_buffer=part.name)
+    state.status_message = None
+    state.dirty = True
+    return state
+
+
+def _auto_ident(state: State, slot: int, size_mb: int) -> str:
+    """Initial type pick when the user hasn't chosen one. AHDI slot 0
+    is forced GEM by the boot rule; later slots flip at the GEM
+    threshold; hybrid formats don't use the field."""
+    if state.format_id != "AHDI":
+        return "GEM"
+    if slot == 0:
+        return "GEM"
+    threshold = (atari_hd.AHDI_GEM_MAX_MB_STRICT if state.strict_tos
+                 else atari_hd.AHDI_GEM_MAX_MB)
+    return "GEM" if size_mb <= threshold else "BGM"
+
+
+# -------------------------------------------------------------------
+# T: cycle type on selected (AHDI non-zero only)
+# -------------------------------------------------------------------
+
+def _toggle_type_inline(state: State) -> State:
+    if not _selected_is_real(state):
+        return state
+    if state.format_id != "AHDI":
+        state.status_message = "Type toggle only applies to AHDI"
+        state.dirty = True
+        return state
+    if state.selected_slot == 0:
+        state.status_message = "slot 0 is locked to GEM (boot rule)"
+        state.dirty = True
+        return state
+    part = state.partitions[state.selected_slot]
+    current = getattr(part, "ahdi_ident", None) or _auto_ident(
+        state, state.selected_slot, part.size_mb)
+    new_ident = "BGM" if current == "GEM" else "GEM"
+    # Verify the new pick keeps the partition within its cap.
+    cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
+                                    new_ident)
+    if part.size_mb > cap:
+        state.status_message = (f"cannot switch to {new_ident}: "
+                                f"size {part.size_mb} MB exceeds {cap} MB cap")
+        state.dirty = True
+        return state
+    part.ahdi_ident = new_ident
+    state.status_message = f"slot {state.selected_slot}: {current} -> {new_ident}"
+    state.dirty = True
+    return state
+
+
+# -------------------------------------------------------------------
+# D: open inline delete confirm prompt
+# -------------------------------------------------------------------
+
+def _open_delete_confirm(state: State) -> State:
+    if not _selected_is_real(state):
+        return state
+    state.prompt_mode = PromptMode.CONFIRM_DELETE
+    state.pending_delete_slot = state.selected_slot
+    state.status_message = None
+    state.dirty = True
+    return state
+
+
+def _handle_delete_confirm(state: State, key) -> State:
+    if isinstance(key, str) and key.lower() == "y":
+        slot = state.pending_delete_slot
+        if slot is not None and 0 <= slot < len(state.partitions):
+            state.partitions[slot] = None
+            state.status_message = f"deleted partition #{slot}"
+        state.pending_delete_slot = None
+        state.prompt_mode = PromptMode.OFF
+        state.dirty = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    # Anything else cancels.
+    state.pending_delete_slot = None
+    state.prompt_mode = PromptMode.OFF
+    state.status_message = "delete cancelled"
+    state.dirty = True
+    return state
+
+
+# -------------------------------------------------------------------
+# Edit dialog key handler
+# -------------------------------------------------------------------
+
+def _handle_edit_dialog(state: State, key) -> State:
+    d = state.edit_dialog
+    if key == Key.ESC:
+        state.edit_dialog = None
+        state.status_message = "cancelled"
+        state.dirty = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    if key == Key.ENTER:
+        return _commit_edit_dialog(state)
+
+    # Tab cycles fields. Skip TYPE on hybrid formats (it's hidden) and
+    # on AHDI slot 0 (locked to GEM, can't be edited).
+    if isinstance(key, str) and key == "\t":
+        return _cycle_edit_field(state)
+
+    # Per-field key dispatch.
+    if d.field == EditField.SIZE:
+        return _edit_size_key(state, key)
+    if d.field == EditField.TYPE:
+        return _edit_type_key(state, key)
+    if d.field == EditField.LABEL:
+        return _edit_label_key(state, key)
+    return state
+
+
+def _cycle_edit_field(state: State) -> State:
+    d = state.edit_dialog
+    type_visible = state.format_id == "AHDI" and d.slot != 0
+    order = [EditField.SIZE]
+    if type_visible:
+        order.append(EditField.TYPE)
+    order.append(EditField.LABEL)
+    idx = order.index(d.field) if d.field in order else 0
+    d.field = order[(idx + 1) % len(order)]
+    state.dirty = True
+    return state
+
+
+def _edit_size_key(state: State, key) -> State:
+    d = state.edit_dialog
+    if isinstance(key, str) and key.isdigit():
+        if len(d.size_buffer) < 6:  # avoid huge inputs
+            d.size_buffer += key
+            state.dirty = True
+        return state
+    if key == Key.BACKSPACE:
+        if d.size_buffer:
+            d.size_buffer = d.size_buffer[:-1]
+            state.dirty = True
+        return state
+    # Save shortcut: 'S' or 's' anywhere commits when valid.
+    if isinstance(key, str) and key.lower() == "s":
+        return _commit_edit_dialog(state)
+    return state
+
+
+def _edit_type_key(state: State, key) -> State:
+    d = state.edit_dialog
+    # Locked on AHDI slot 0; should never reach this in normal flow,
+    # but guard for safety.
+    if state.format_id == "AHDI" and d.slot == 0:
+        return state
+    if state.format_id != "AHDI":
+        return state
+    if key in (Key.LEFT, Key.RIGHT) or (isinstance(key, str) and key == "t"):
+        d.type_choice = "BGM" if d.type_choice == "GEM" else "GEM"
+        state.dirty = True
+        return state
+    if isinstance(key, str) and key.lower() == "s":
+        return _commit_edit_dialog(state)
+    return state
+
+
+def _edit_label_key(state: State, key) -> State:
+    d = state.edit_dialog
+    if key == Key.BACKSPACE:
+        if d.label_buffer:
+            d.label_buffer = d.label_buffer[:-1]
+            state.dirty = True
+        return state
+    if isinstance(key, str) and len(key) == 1:
+        # Save shortcut: capital S only here -- a lowercase 's' would
+        # be a legitimate label character. Capital S still saves.
+        if key == "S" and is_legal_label_char(key):
+            # Treat as label char OR save? We pick label-char when the
+            # field is LABEL: typing "S" extends the label. The spec
+            # offers Enter or 'S' as save shortcuts; in the LABEL
+            # field, Enter is the only one to avoid this ambiguity.
+            if len(d.label_buffer) < 11:
+                d.label_buffer += key.upper()
+                state.dirty = True
+            return state
+        if is_legal_label_char(key):
+            if len(d.label_buffer) < 11:
+                d.label_buffer += key.upper()
+                state.dirty = True
+        return state
+    return state
+
+
+def _commit_edit_dialog(state: State) -> State:
+    err = validate_edit_dialog(state)
+    if err is not None:
+        state.status_message = f"cannot save: {err}"
+        state.dirty = True
+        return state
+    d = state.edit_dialog
+    size_mb = int(d.size_buffer)
+    label = d.label_buffer or _default_label(state, d.slot)
+    # Force GEM on AHDI slot 0 regardless of d.type_choice (defensive).
+    ident = ("GEM" if state.format_id == "AHDI" and d.slot == 0
+             else d.type_choice)
+
+    if d.mode == EditMode.ADD:
+        part = atari_hd.Partition(name=label, size_mb=size_mb)
+    else:
+        part = state.partitions[d.slot]
+        part.name = label
+        part.size_mb = size_mb
+    part.ahdi_ident = ident
+
+    # Place the partition in its slot. For ADD, slot might be a hole
+    # (existing None entry) or len(partitions) (append).
+    while len(state.partitions) <= d.slot:
+        state.partitions.append(None)
+    state.partitions[d.slot] = part
+    state.selected_slot = d.slot
+    state.edit_dialog = None
+    state.status_message = (f"slot {d.slot}: {label} {size_mb} MB"
+                            + (f" {ident}" if state.format_id == "AHDI" else ""))
+    state.dirty = True
+    return state
+
+
+def _default_label(state: State, slot: int) -> str:
+    # First slot is the boot partition by AHDI convention; pick a
+    # readable default. Other slots get "P<N+1>" so the user doesn't
+    # have to type one.
+    if slot == 0 and state.format_id == "AHDI":
+        return "BOOT"
+    return f"P{slot + 1}"
 
 
 # -------------------------------------------------------------------
@@ -131,7 +431,6 @@ def _handle_partition_action_stub(state: State, k: str) -> State:
 
 def _handle_text_prompt(state: State, key) -> State:
     if key == Key.ESC:
-        # Cancel the prompt; clear buffer.
         state.prompt_mode = PromptMode.OFF
         state.prompt_buffer = ""
         state.dirty = True
@@ -153,10 +452,10 @@ def _handle_text_prompt(state: State, key) -> State:
 
 
 def _commit_text_prompt(state: State) -> State:
+    import os
     path = state.prompt_buffer.strip()
     mode = state.prompt_mode
     if not path:
-        # Empty input -> just cancel quietly.
         state.prompt_mode = PromptMode.OFF
         state.prompt_buffer = ""
         state.dirty = True
@@ -177,8 +476,6 @@ def _commit_text_prompt(state: State) -> State:
             state.prompt_mode = PromptMode.OFF
             state.status_message = f"file not found: {path}"
         else:
-            # Story 007 will actually parse the file; until then we
-            # just remember the path and surface a placeholder note.
             state.image_path = path
             state.prompt_mode = PromptMode.OFF
             state.status_message = "load not yet implemented (story 007)"
@@ -192,7 +489,6 @@ def _commit_text_prompt(state: State) -> State:
 # -------------------------------------------------------------------
 
 def _handle_overwrite_confirm(state: State, key) -> State:
-    # Spec: 'O' (capital) confirms; anything else cancels.
     if isinstance(key, str) and key == "O":
         state.image_path = state.pending_path
         state.pending_path = None
@@ -203,8 +499,6 @@ def _handle_overwrite_confirm(state: State, key) -> State:
     if key == Key.CTRL_C:
         state.exit_requested = True
         return state
-    # Anything else cancels -- including ESC, lowercase 'o',
-    # printable chars, and Enter.
     state.pending_path = None
     state.prompt_mode = PromptMode.OFF
     state.status_message = "overwrite cancelled"
@@ -221,6 +515,7 @@ def main() -> int:
     with terminal_session():
         while not state.exit_requested:
             if state.dirty:
+                from .render import render
                 sys.stdout.write(render(state))
                 sys.stdout.flush()
                 state.dirty = False

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -734,6 +734,17 @@ def _do_load(state: State, path: str) -> State:
     if loaded.get("strict_tos_inferred"):
         msg += (f"  [TOS<1.04: "
                 f"{'on' if state.strict_tos else 'off'} -- guessed]")
+    # Surface the first compatibility warning (when present) so a user
+    # loading a foreign-tool image (mkdosfs, acsi2stm, Falcon-format,
+    # ...) sees the salient issue immediately. The full list is on
+    # the planning summary if a future story wants a help/details
+    # screen.
+    warnings = loaded.get("warnings") or []
+    if warnings:
+        extra = warnings[0]
+        if len(warnings) > 1:
+            extra = f"{extra} (+{len(warnings) - 1} more)"
+        msg += f"  WARNING: {extra}"
     state.status_message = msg
     return state
 

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -30,6 +30,27 @@ from .terminal import terminal_session
 MAX_PARTITIONS = 14
 
 
+def _primary_count_for_state(state, *, count_dialog_add=False) -> int:
+    """Compute primary_count for partition_layout given the current
+    state. PPDRIVER allows up to 4 primaries; HDDRIVER caps at 1; AHDI
+    uses up to 4 AHDI-table slots.
+
+    `count_dialog_add` is True when an ADD dialog is open and we want
+    the layout the writer would produce *after* the user commits --
+    important for the dialog's live cap label so the user sees the
+    right primary/logical cap at the slot they're about to fill.
+    """
+    n = sum(1 for p in state.partitions if p is not None)
+    if count_dialog_add and state.edit_dialog and \
+            state.edit_dialog.mode == EditMode.ADD:
+        n += 1
+    if n < 1:
+        n = 1
+    if n > MAX_PARTITIONS:
+        n = MAX_PARTITIONS
+    return atari_hd.partition_layout(state.format_id, n)["primary_count"]
+
+
 def handle_key(state: State, key) -> State:
     """Dispatch one keypress into a state mutation. Returns the same
     state (mutated in place) for symmetry with future immutable-state
@@ -242,9 +263,21 @@ def _open_add_dialog(state: State) -> State:
     type_choice = "GEM" if state.format_id != "AHDI" or is_first else "BGM"
     if state.format_id != "AHDI":
         type_choice = "GEM"  # arbitrary; ignored for hybrid formats
+    # Default Kind: slot 0 -> primary (mandatory). HDDRIVER slot >= 1 ->
+    # extended (mandatory). PPDRIVER slot >= 1 -> default extended,
+    # since the typical "second partition is the bulk DATA" workflow
+    # wants 511 MB headroom; the user can flip back to primary via
+    # the Kind toggle if they want a small primary instead.
+    if is_first:
+        kind_choice = "primary"
+    elif state.format_id == "HDDRIVER":
+        kind_choice = "extended"
+    else:
+        kind_choice = "extended"
     state.edit_dialog = EditDialogState(
         mode=EditMode.ADD, slot=slot, field=EditField.SIZE,
-        size_buffer="", type_choice=type_choice, label_buffer="")
+        size_buffer="", type_choice=type_choice,
+        kind_choice=kind_choice, label_buffer="")
     state.status_message = None
     state.dirty = True
     return state
@@ -263,10 +296,21 @@ def _open_edit_dialog(state: State) -> State:
     # (set at creation time below) or fall back to the auto-pick.
     ident = getattr(part, "ahdi_ident", None) or _auto_ident(state, slot,
                                                               part.size_mb)
+    # Kind is locked for slot 0 / HDDRIVER; for PPDRIVER slot >= 1 we
+    # carry over the partition's existing is_extended.
+    if slot == 0:
+        kind_choice = "primary"
+    elif state.format_id == "HDDRIVER":
+        kind_choice = "extended"
+    else:
+        kind_choice = ("extended"
+                        if getattr(part, "is_extended", False)
+                        else "primary")
     state.edit_dialog = EditDialogState(
         mode=EditMode.EDIT, slot=slot, field=EditField.SIZE,
         size_buffer=str(part.size_mb),
         type_choice=ident,
+        kind_choice=kind_choice,
         label_buffer=part.name)
     state.status_message = None
     state.dirty = True
@@ -472,12 +516,22 @@ def _find_violator_slots(state: State, candidate_format: str,
     exceed the candidate format's per-type cap. Empty list means the
     format change is cap-safe."""
     violators = []
+    # Compute primary_count under the candidate layout so the
+    # primary-vs-logical decision honours the format we're switching to,
+    # not the current state.format_id. AHDI's cap path doesn't consult
+    # primary_count, so a wrong value there is harmless.
+    n = sum(1 for p in state.partitions if p is not None) or 1
+    if n > MAX_PARTITIONS:
+        n = MAX_PARTITIONS
+    candidate_primary = atari_hd.partition_layout(candidate_format,
+                                                    n)["primary_count"]
     for i, part in enumerate(state.partitions):
         if part is None:
             continue
         ident = _effective_ident(state, i, part, candidate_format)
         cap = atari_hd.cap_mb_for_type(candidate_format, candidate_strict,
-                                        ident, slot_index=i)
+                                        ident, slot_index=i,
+                                        primary_count=candidate_primary)
         if part.size_mb > cap:
             violators.append(i)
     return violators
@@ -517,6 +571,8 @@ def _handle_edit_dialog(state: State, key) -> State:
         return _cycle_edit_field(state)
 
     # Per-field key dispatch.
+    if d.field == EditField.KIND:
+        return _edit_kind_key(state, key)
     if d.field == EditField.SIZE:
         return _edit_size_key(state, key)
     if d.field == EditField.TYPE:
@@ -529,13 +585,36 @@ def _handle_edit_dialog(state: State, key) -> State:
 def _cycle_edit_field(state: State) -> State:
     d = state.edit_dialog
     type_visible = state.format_id == "AHDI" and d.slot != 0
-    order = [EditField.SIZE]
+    # KIND is the user's free choice only on PPDRIVER slot >= 1.
+    # Slot 0 (always primary) and HDDRIVER slot >= 1 (always extended)
+    # have the kind locked and skipped from the Tab order.
+    kind_editable = (state.format_id == "PPDRIVER" and d.slot != 0)
+    order = []
+    if kind_editable:
+        order.append(EditField.KIND)
+    order.append(EditField.SIZE)
     if type_visible:
         order.append(EditField.TYPE)
     order.append(EditField.LABEL)
     idx = order.index(d.field) if d.field in order else 0
     d.field = order[(idx + 1) % len(order)]
     state.dirty = True
+    return state
+
+
+def _edit_kind_key(state: State, key) -> State:
+    """Toggle Kind (primary <-> extended) on hybrid PPDRIVER slot >= 1."""
+    d = state.edit_dialog
+    # Locked: nothing to do.
+    if state.format_id != "PPDRIVER" or d.slot == 0:
+        return state
+    if key in (Key.LEFT, Key.RIGHT) or (isinstance(key, str) and key == "t"):
+        d.kind_choice = ("extended" if d.kind_choice == "primary"
+                          else "primary")
+        state.dirty = True
+        return state
+    if isinstance(key, str) and key.lower() == "s":
+        return _commit_edit_dialog(state)
     return state
 
 
@@ -614,12 +693,29 @@ def _commit_edit_dialog(state: State) -> State:
     ident = ("GEM" if state.format_id == "AHDI" and d.slot == 0
              else d.type_choice)
 
+    # Resolve the on-disk Kind: slot 0 is always primary; HDDRIVER
+    # slot >= 1 is always extended; PPDRIVER slot >= 1 follows
+    # d.kind_choice. AHDI partitions don't expose Kind in the dialog
+    # (still derived at write time), so we leave is_extended at the
+    # dataclass default for AHDI; plan_image will reset it from the
+    # AHDI N-driven layout regardless.
+    if d.slot == 0:
+        is_extended = False
+    elif state.format_id == "HDDRIVER":
+        is_extended = True
+    elif state.format_id == "PPDRIVER":
+        is_extended = (d.kind_choice == "extended")
+    else:
+        is_extended = False  # AHDI; plan_image overrides per N
+
     if d.mode == EditMode.ADD:
-        part = atari_hd.Partition(name=label, size_mb=size_mb)
+        part = atari_hd.Partition(name=label, size_mb=size_mb,
+                                    is_extended=is_extended)
     else:
         part = state.partitions[d.slot]
         part.name = label
         part.size_mb = size_mb
+        part.is_extended = is_extended
     part.ahdi_ident = ident
 
     # Place the partition in its slot. For ADD, slot might be a hole
@@ -798,6 +894,7 @@ def _preflight_check(state: State):
     if not real:
         return "no partitions to write"
     min_mb = atari_hd.format_min_partition_mb(state.format_id)
+    primary_count = _primary_count_for_state(state)
     for i, part in enumerate(real):
         if part.size_mb < min_mb:
             return (f"partition {part.name!r} ({part.size_mb} MB) is "
@@ -805,7 +902,8 @@ def _preflight_check(state: State):
                     f"{state.format_id}")
         ident = _effective_ident(state, i, part, state.format_id)
         cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
-                                        ident, slot_index=i)
+                                        ident, slot_index=i,
+                                        primary_count=primary_count)
         if part.size_mb > cap:
             return (f"partition {part.name!r} ({part.size_mb} MB) "
                     f"exceeds {cap} MB cap")

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -274,18 +274,14 @@ def _open_edit_dialog(state: State) -> State:
 
 
 def _auto_ident(state: State, slot: int, size_mb: int) -> str:
-    """Initial type pick when the user hasn't chosen one. AHDI slot 0
-    is clamped to GEM as a legacy-driver compatibility default (not a
-    hard TOS rule -- see atari_hd.ahdi_partition_id() for the
-    rationale); later slots flip at the GEM threshold; hybrid formats
-    don't use the field."""
+    """Initial type pick when the user hasn't chosen one. The AHDI ident
+    follows bps strictly (GEM iff bps=512, BGM iff bps>512), so we
+    delegate to ahdi_partition_id(). Slot 0 still ends up as GEM
+    because partition_cap_mb() caps it at the GEM region; we just
+    don't special-case it here."""
     if state.format_id != "AHDI":
         return "GEM"
-    if slot == 0:
-        return "GEM"
-    threshold = (atari_hd.AHDI_GEM_MAX_MB_STRICT if state.strict_tos
-                 else atari_hd.AHDI_GEM_MAX_MB)
-    return "GEM" if size_mb <= threshold else "BGM"
+    return atari_hd.ahdi_partition_id(size_mb).decode()
 
 
 # -------------------------------------------------------------------
@@ -488,23 +484,13 @@ def _find_violator_slots(state: State, candidate_format: str,
 
 
 def _effective_ident(state: State, slot: int, part, format_id: str) -> str:
-    """The ident the new format would assign this partition. AHDI
-    slot 0 is clamped to GEM (legacy-driver compatibility default);
-    later AHDI slots honor an existing ahdi_ident if set, else
-    auto-pick by the GEM threshold (using the *candidate* strict_tos,
-    not the current state, so the violation check is honest about the
-    new regime)."""
+    """The ident the new format would assign this partition. AHDI ident
+    follows bps strictly (delegated to ahdi_partition_id); explicit
+    ahdi_ident overrides are honored only when consistent with the bps
+    derived from size, so we just return the size-derived value."""
     if format_id != "AHDI":
         return "FAT16"
-    if slot == 0:
-        return "GEM"
-    explicit = getattr(part, "ahdi_ident", None)
-    if explicit in ("GEM", "BGM", b"GEM", b"BGM"):
-        return explicit if isinstance(explicit, str) else explicit.decode()
-    threshold = (atari_hd.AHDI_GEM_MAX_MB_STRICT
-                 if state.pending_strict_tos
-                 else atari_hd.AHDI_GEM_MAX_MB)
-    return "GEM" if part.size_mb <= threshold else "BGM"
+    return atari_hd.ahdi_partition_id(part.size_mb).decode()
 
 
 # -------------------------------------------------------------------

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -688,7 +688,6 @@ def _commit_edit_dialog(state: State) -> State:
         return state
     d = state.edit_dialog
     size_mb = int(d.size_buffer)
-    label = d.label_buffer or _default_label(state, d.slot)
     # Force GEM on AHDI slot 0 regardless of d.type_choice (defensive).
     ident = ("GEM" if state.format_id == "AHDI" and d.slot == 0
              else d.type_choice)
@@ -707,6 +706,10 @@ def _commit_edit_dialog(state: State) -> State:
         is_extended = (d.kind_choice == "extended")
     else:
         is_extended = False  # AHDI; plan_image overrides per N
+
+    # Default label uses the resolved Kind: 'P' prefix for primaries,
+    # 'E' for extendeds. AHDI slot 0 stays 'BOOT'.
+    label = d.label_buffer or _default_label(state, d.slot, is_extended)
 
     if d.mode == EditMode.ADD:
         part = atari_hd.Partition(name=label, size_mb=size_mb,
@@ -740,13 +743,15 @@ def _commit_edit_dialog(state: State) -> State:
     return state
 
 
-def _default_label(state: State, slot: int) -> str:
-    # First slot is the boot partition by AHDI convention; pick a
-    # readable default. Other slots get "P<N+1>" so the user doesn't
-    # have to type one.
+def _default_label(state: State, slot: int, is_extended: bool = False) -> str:
+    # First slot on AHDI is the boot partition; pick a readable
+    # default. Other slots get a prefix that reflects the partition's
+    # role -- "P<N+1>" for primaries, "E<N+1>" for extendeds -- so a
+    # mixed PPDRIVER layout reads cleanly: BOOT (or P1), E2, E3, ...
     if slot == 0 and state.format_id == "AHDI":
         return "BOOT"
-    return f"P{slot + 1}"
+    prefix = "E" if is_extended else "P"
+    return f"{prefix}{slot + 1}"
 
 
 # -------------------------------------------------------------------

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -10,12 +10,16 @@ confirm prompt; the main-screen handler dispatches A / D / E / T to
 those, and W remains a story-006 stub.
 """
 
+import os
+import shutil
 import sys
+import tempfile
 
 import atari_hd
 
 from .input import Key, read_key
-from .render import is_legal_label_char, validate_edit_dialog
+from .render import (MIN_COLS, MIN_ROWS,
+                      is_legal_label_char, validate_edit_dialog)
 from .state import (EditDialogState, EditField, EditMode, PromptMode,
                     State)
 from .terminal import terminal_session
@@ -54,6 +58,10 @@ def handle_key(state: State, key) -> State:
         return _handle_ask_strict_tos(state, key)
     if state.prompt_mode == PromptMode.CONFIRM_DROP_PARTITIONS:
         return _handle_drop_confirm(state, key)
+    if state.prompt_mode == PromptMode.CONFIRM_OVERWRITE_WRITE:
+        return _handle_write_overwrite_confirm(state, key)
+    if state.prompt_mode == PromptMode.CONFIRM_DISCARD_UNSAVED:
+        return _handle_discard_unsaved_confirm(state, key)
     return state
 
 
@@ -77,8 +85,7 @@ def _handle_main(state: State, key) -> State:
         return state
     k = key.lower()
     if k == "q":
-        state.exit_requested = True
-        return state
+        return _request_exit(state)
 
     # File-management actions are only available before an image is
     # loaded; once the user has an image, the keybindings switch to
@@ -139,11 +146,7 @@ def _handle_partition_action(state: State, k: str) -> State:
     if k == "f":
         return _open_format_chooser(state)
     if k == "w":
-        # Real handler lands in story 006.
-        if _has_real_partitions(state):
-            state.status_message = "story 006 implements Write"
-            state.dirty = True
-        return state
+        return _start_write(state)
     return state
 
 
@@ -204,8 +207,10 @@ def _open_edit_dialog(state: State) -> State:
 
 def _auto_ident(state: State, slot: int, size_mb: int) -> str:
     """Initial type pick when the user hasn't chosen one. AHDI slot 0
-    is forced GEM by the boot rule; later slots flip at the GEM
-    threshold; hybrid formats don't use the field."""
+    is clamped to GEM as a legacy-driver compatibility default (not a
+    hard TOS rule -- see atari_hd.ahdi_partition_id() for the
+    rationale); later slots flip at the GEM threshold; hybrid formats
+    don't use the field."""
     if state.format_id != "AHDI":
         return "GEM"
     if slot == 0:
@@ -227,7 +232,8 @@ def _toggle_type_inline(state: State) -> State:
         state.dirty = True
         return state
     if state.selected_slot == 0:
-        state.status_message = "slot 0 is locked to GEM (boot rule)"
+        state.status_message = ("slot 0 is locked to GEM "
+                                 "(legacy-driver compatibility)")
         state.dirty = True
         return state
     part = state.partitions[state.selected_slot]
@@ -243,6 +249,7 @@ def _toggle_type_inline(state: State) -> State:
         state.dirty = True
         return state
     part.ahdi_ident = new_ident
+    state.unsaved_changes = True
     state.status_message = f"slot {state.selected_slot}: {current} -> {new_ident}"
     state.dirty = True
     return state
@@ -268,6 +275,7 @@ def _handle_delete_confirm(state: State, key) -> State:
         if slot is not None and 0 <= slot < len(state.partitions):
             state.partitions[slot] = None
             state.status_message = f"deleted partition #{slot}"
+            state.unsaved_changes = True
         state.pending_delete_slot = None
         state.prompt_mode = PromptMode.OFF
         state.dirty = True
@@ -366,11 +374,16 @@ def _handle_drop_confirm(state: State, key) -> State:
 def _apply_pending_format(state: State, drop_slots) -> State:
     new_format = state.pending_format
     new_strict = state.pending_strict_tos or False
+    actually_changed = (new_format != state.format_id
+                        or new_strict != state.strict_tos
+                        or bool(drop_slots))
     for slot in drop_slots:
         if 0 <= slot < len(state.partitions):
             state.partitions[slot] = None
     state.format_id = new_format
     state.strict_tos = new_strict
+    if actually_changed:
+        state.unsaved_changes = True
     msg = f"format -> {new_format}"
     if new_format == "AHDI":
         msg += f" (TOS<1.04: {'on' if new_strict else 'off'})"
@@ -408,10 +421,11 @@ def _find_violator_slots(state: State, candidate_format: str,
 
 def _effective_ident(state: State, slot: int, part, format_id: str) -> str:
     """The ident the new format would assign this partition. AHDI
-    slot 0 is forced GEM; later AHDI slots honor an existing
-    ahdi_ident if set, else auto-pick by the GEM threshold (slot
-    threshold uses the *candidate* strict_tos, not the current state,
-    so the violation check is honest about the new regime)."""
+    slot 0 is clamped to GEM (legacy-driver compatibility default);
+    later AHDI slots honor an existing ahdi_ident if set, else
+    auto-pick by the GEM threshold (using the *candidate* strict_tos,
+    not the current state, so the violation check is honest about the
+    new regime)."""
     if format_id != "AHDI":
         return "FAT16"
     if slot == 0:
@@ -443,7 +457,8 @@ def _handle_edit_dialog(state: State, key) -> State:
         return _commit_edit_dialog(state)
 
     # Tab cycles fields. Skip TYPE on hybrid formats (it's hidden) and
-    # on AHDI slot 0 (locked to GEM, can't be edited).
+    # on AHDI slot 0 (clamped to GEM for legacy-driver compatibility,
+    # not user-editable in v1).
     if isinstance(key, str) and key == "\t":
         return _cycle_edit_field(state)
 
@@ -560,6 +575,7 @@ def _commit_edit_dialog(state: State) -> State:
     state.partitions[d.slot] = part
     state.selected_slot = d.slot
     state.edit_dialog = None
+    state.unsaved_changes = True
     state.status_message = (f"slot {d.slot}: {label} {size_mb} MB"
                             + (f" {ident}" if state.format_id == "AHDI" else ""))
     state.dirty = True
@@ -652,6 +668,166 @@ def _handle_overwrite_confirm(state: State, key) -> State:
     state.pending_path = None
     state.prompt_mode = PromptMode.OFF
     state.status_message = "overwrite cancelled"
+    state.dirty = True
+    return state
+
+
+# -------------------------------------------------------------------
+# W: commit / write flow (story 006)
+# -------------------------------------------------------------------
+
+def _start_write(state: State) -> State:
+    """Run the pre-flight checks; if the target file already exists,
+    open the overwrite-confirm prompt; otherwise proceed straight to
+    the write."""
+    err = _preflight_check(state)
+    if err is not None:
+        state.status_message = f"cannot write: {err}"
+        state.dirty = True
+        return state
+    if os.path.exists(state.image_path):
+        state.prompt_mode = PromptMode.CONFIRM_OVERWRITE_WRITE
+        state.dirty = True
+        return state
+    return _do_write(state)
+
+
+def _preflight_check(state: State):
+    """Return None when every pre-flight rule passes, otherwise a
+    short reason string. Doesn't mutate state."""
+    real = [p for p in state.partitions if p is not None]
+    if not real:
+        return "no partitions to write"
+    for i, part in enumerate(real):
+        ident = _effective_ident(state, i, part, state.format_id)
+        cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
+                                        ident)
+        if part.size_mb > cap:
+            return (f"partition {part.name!r} ({part.size_mb} MB) "
+                    f"exceeds {cap} MB cap")
+    return None
+
+
+def _handle_write_overwrite_confirm(state: State, key) -> State:
+    if isinstance(key, str) and key.lower() == "y":
+        state.prompt_mode = PromptMode.OFF
+        return _do_write(state)
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    state.prompt_mode = PromptMode.OFF
+    state.status_message = "write cancelled"
+    state.dirty = True
+    return state
+
+
+def _do_write(state: State) -> State:
+    """Build the plan and call atari_hd.build_image() into a temp
+    file in the same directory, then os.replace into the target.
+    Atomic so a partial write never overwrites the existing file."""
+    target = state.image_path
+    target_dir = os.path.dirname(os.path.abspath(target)) or "."
+    real_partitions = [p for p in state.partitions if p is not None]
+
+    # Compute a generous initial image size; plan_image will bump it
+    # if the partitions need more headroom (root sector + EBR / XGM
+    # chain overhead).
+    total_partition_mb = sum(p.size_mb for p in real_partitions)
+    image_mb = max(total_partition_mb + 1, 2)
+
+    tmp_path = None
+    try:
+        # tempfile in the same directory so os.replace() is atomic
+        # (same filesystem). delete=False -> we own cleanup.
+        tmp = tempfile.NamedTemporaryFile(
+            prefix="atari_hd_write_", suffix=".img.tmp",
+            dir=target_dir, delete=False)
+        tmp_path = tmp.name
+        tmp.close()
+
+        # Fresh Partition objects so plan_image's mutations
+        # (size_sectors / start_lba / etc.) don't leak back into our
+        # in-memory list.
+        plan_partitions = []
+        for src in real_partitions:
+            new = atari_hd.Partition(name=src.name, size_mb=src.size_mb)
+            # Preserve the user's explicit ident so XGM-chain logicals
+            # render the right type if the user picked one. (Currently
+            # ahdi_partition_id ignores this for XGM logicals; a
+            # follow-up could thread it through. v1 is OK.)
+            ident = getattr(src, "ahdi_ident", None)
+            if ident is not None:
+                new.ahdi_ident = ident
+            plan_partitions.append(new)
+
+        plan = atari_hd.plan_image(
+            state.format_id, image_path=tmp_path, image_mb=image_mb,
+            partitions=plan_partitions, strict_tos=state.strict_tos)
+
+        atari_hd.build_image(plan, progress=_make_progress_callback())
+
+        os.replace(tmp_path, target)
+        tmp_path = None  # successfully consumed
+    except KeyboardInterrupt:
+        # Don't swallow; let the terminal_session restore + propagate.
+        if tmp_path is not None:
+            try: os.unlink(tmp_path)
+            except OSError: pass
+        raise
+    except Exception as e:
+        if tmp_path is not None:
+            try: os.unlink(tmp_path)
+            except OSError: pass
+        state.status_message = f"write failed: {e}"
+        state.dirty = True
+        return state
+
+    state.status_message = (f"Written {len(real_partitions)} "
+                            f"partition(s) to {target}")
+    state.unsaved_changes = False
+    state.dirty = True
+    return state
+
+
+def _make_progress_callback():
+    """Build a callback that overwrites the bottom row in place
+    during the write. The callback is invoked synchronously from
+    inside build_image while terminal_session holds the alt screen,
+    so direct stdout writes are safe."""
+    def emit(message):
+        size = shutil.get_terminal_size((MIN_COLS, MIN_ROWS))
+        cols, rows = size.columns, size.lines
+        line = message[:cols].ljust(cols)
+        # Move to last row, clear it, write, no newline.
+        sys.stdout.write(f"\x1b[{rows};1H\x1b[2K{line}")
+        sys.stdout.flush()
+    return emit
+
+
+# -------------------------------------------------------------------
+# Q: exit (with unsaved-changes guard, story 006)
+# -------------------------------------------------------------------
+
+def _request_exit(state: State) -> State:
+    """Q at the main screen: guard against quitting with unsaved
+    in-memory changes. ESC follows the same path."""
+    if state.unsaved_changes:
+        state.prompt_mode = PromptMode.CONFIRM_DISCARD_UNSAVED
+        state.dirty = True
+        return state
+    state.exit_requested = True
+    return state
+
+
+def _handle_discard_unsaved_confirm(state: State, key) -> State:
+    if isinstance(key, str) and key.lower() == "y":
+        state.exit_requested = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    state.prompt_mode = PromptMode.OFF
+    state.status_message = "exit cancelled"
     state.dirty = True
     return state
 

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -1,0 +1,41 @@
+"""Event loop and key dispatch.
+
+A single boring loop: read a key, mutate state, redraw on the dirty
+flag, repeat until exit_requested. No threads, no async, no signal
+handlers. See DECISIONS.md sections 3 and 4.
+"""
+
+import sys
+
+from .input import Key, read_key
+from .render import render
+from .state import State
+from .terminal import terminal_session
+
+
+def handle_key(state: State, key) -> State:
+    """Dispatch one keypress into a state mutation. Returns the same
+    state object (mutated in place) for symmetry with future
+    immutable-state refactors -- callers must not assume identity is
+    preserved across calls."""
+    if key in (Key.ESC, Key.CTRL_C):
+        state.exit_requested = True
+        return state
+    if isinstance(key, str) and key.lower() == "q":
+        state.exit_requested = True
+        return state
+    return state
+
+
+def main() -> int:
+    """Run the TUI. Returns a process exit code."""
+    state = State()
+    with terminal_session():
+        while not state.exit_requested:
+            if state.dirty:
+                sys.stdout.write(render(state))
+                sys.stdout.flush()
+                state.dirty = False
+            key = read_key()
+            state = handle_key(state, key)
+    return 0

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -516,10 +516,9 @@ def _find_violator_slots(state: State, candidate_format: str,
     exceed the candidate format's per-type cap. Empty list means the
     format change is cap-safe."""
     violators = []
-    # Compute primary_count under the candidate layout so the
-    # primary-vs-logical decision honours the format we're switching to,
-    # not the current state.format_id. AHDI's cap path doesn't consult
-    # primary_count, so a wrong value there is harmless.
+    is_hybrid = candidate_format in ("PPDRIVER", "HDDRIVER")
+    # AHDI's cap_mb_for_type still consults primary_count for slot 0
+    # vs. >=1 ident routing; hybrid uses per-partition is_extended.
     n = sum(1 for p in state.partitions if p is not None) or 1
     if n > MAX_PARTITIONS:
         n = MAX_PARTITIONS
@@ -528,10 +527,15 @@ def _find_violator_slots(state: State, candidate_format: str,
     for i, part in enumerate(state.partitions):
         if part is None:
             continue
-        ident = _effective_ident(state, i, part, candidate_format)
-        cap = atari_hd.cap_mb_for_type(candidate_format, candidate_strict,
-                                        ident, slot_index=i,
-                                        primary_count=candidate_primary)
+        if is_hybrid:
+            cap = (atari_hd.HYBRID_PRIMARY_MAX_MB
+                   if not part.is_extended
+                   else atari_hd.HYBRID_MAX_PARTITION_MB)
+        else:
+            ident = _effective_ident(state, i, part, candidate_format)
+            cap = atari_hd.cap_mb_for_type(candidate_format, candidate_strict,
+                                            ident, slot_index=i,
+                                            primary_count=candidate_primary)
         if part.size_mb > cap:
             violators.append(i)
     return violators
@@ -908,15 +912,26 @@ def _preflight_check(state: State):
         return "no partitions to write"
     min_mb = atari_hd.format_min_partition_mb(state.format_id)
     primary_count = _primary_count_for_state(state)
+    is_hybrid = state.format_id in ("PPDRIVER", "HDDRIVER")
     for i, part in enumerate(real):
         if part.size_mb < min_mb:
             return (f"partition {part.name!r} ({part.size_mb} MB) is "
                     f"below the {min_mb} MB minimum for "
                     f"{state.format_id}")
-        ident = _effective_ident(state, i, part, state.format_id)
-        cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
-                                        ident, slot_index=i,
-                                        primary_count=primary_count)
+        if is_hybrid:
+            # Hybrid caps follow the per-partition is_extended flag,
+            # not the slot index. After load_image's auto-migration,
+            # an oversize-on-disk primary may have is_extended=True
+            # even though it lives at a low slot index; using
+            # slot_index/primary_count would mis-cap it as a primary
+            # and reject the write.
+            cap = (atari_hd.HYBRID_PRIMARY_MAX_MB if not part.is_extended
+                   else atari_hd.HYBRID_MAX_PARTITION_MB)
+        else:
+            ident = _effective_ident(state, i, part, state.format_id)
+            cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
+                                            ident, slot_index=i,
+                                            primary_count=primary_count)
         if part.size_mb > cap:
             return (f"partition {part.name!r} ({part.size_mb} MB) "
                     f"exceeds {cap} MB cap")

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -716,7 +716,15 @@ def _commit_edit_dialog(state: State) -> State:
         part.name = label
         part.size_mb = size_mb
         part.is_extended = is_extended
-    part.ahdi_ident = ident
+    # ahdi_ident is an AHDI-table concept (GEM / BGM / XGM); it has no
+    # meaning on hybrid formats whose MBR-side identity is type 0x06
+    # FAT16. Setting it on a PPDRIVER / HDDRIVER partition would
+    # confuse _partition_ident's display logic into showing "GEM" /
+    # "BGM" in the Type column instead of "FAT16".
+    if state.format_id == "AHDI":
+        part.ahdi_ident = ident
+    else:
+        part.ahdi_ident = None
 
     # Place the partition in its slot. For ADD, slot might be a hole
     # (existing None entry) or len(partitions) (append).

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -62,6 +62,8 @@ def handle_key(state: State, key) -> State:
         return _handle_write_overwrite_confirm(state, key)
     if state.prompt_mode == PromptMode.CONFIRM_DISCARD_UNSAVED:
         return _handle_discard_unsaved_confirm(state, key)
+    if state.prompt_mode == PromptMode.CONFIRM_DISCARD_BEFORE_LOAD:
+        return _handle_discard_before_load_confirm(state, key)
     return state
 
 
@@ -87,23 +89,53 @@ def _handle_main(state: State, key) -> State:
     if k == "q":
         return _request_exit(state)
 
-    # File-management actions are only available before an image is
-    # loaded; once the user has an image, the keybindings switch to
-    # partition operations.
-    if state.image_path is None:
-        if k == "n":
-            state.prompt_mode = PromptMode.ASK_NEW_PATH
-            state.prompt_buffer = ""
-            state.status_message = None
-            state.dirty = True
-        elif k == "l":
-            state.prompt_mode = PromptMode.ASK_LOAD_PATH
-            state.prompt_buffer = ""
-            state.status_message = None
-            state.dirty = True
+    # File-management actions (N, L) are always available so the user
+    # can load a different image mid-session. L routes through the
+    # unsaved-changes guard when there's an in-memory plan that would
+    # otherwise be silently discarded.
+    if k == "n":
+        state.prompt_mode = PromptMode.ASK_NEW_PATH
+        state.prompt_buffer = ""
+        state.status_message = None
+        state.dirty = True
         return state
+    if k == "l":
+        return _start_load(state)
 
+    # Partition operations only when an image is set.
+    if state.image_path is None:
+        return state
     return _handle_partition_action(state, k)
+
+
+def _start_load(state: State) -> State:
+    """Open ASK_LOAD_PATH, but if there are unsaved in-memory changes
+    first route through CONFIRM_DISCARD_BEFORE_LOAD so the user
+    doesn't silently lose them. Mirrors the Q exit-guard pattern."""
+    if state.unsaved_changes:
+        state.prompt_mode = PromptMode.CONFIRM_DISCARD_BEFORE_LOAD
+        state.dirty = True
+        return state
+    state.prompt_mode = PromptMode.ASK_LOAD_PATH
+    state.prompt_buffer = ""
+    state.status_message = None
+    state.dirty = True
+    return state
+
+
+def _handle_discard_before_load_confirm(state: State, key) -> State:
+    if isinstance(key, str) and key.lower() == "y":
+        state.prompt_mode = PromptMode.ASK_LOAD_PATH
+        state.prompt_buffer = ""
+        state.dirty = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    state.prompt_mode = PromptMode.OFF
+    state.status_message = "load cancelled"
+    state.dirty = True
+    return state
 
 
 def _handle_navigation(state: State, key) -> State:
@@ -641,12 +673,46 @@ def _commit_text_prompt(state: State) -> State:
         if not os.path.exists(path):
             state.prompt_mode = PromptMode.OFF
             state.status_message = f"file not found: {path}"
-        else:
-            state.image_path = path
-            state.prompt_mode = PromptMode.OFF
-            state.status_message = "load not yet implemented (story 007)"
+            state.dirty = True
+            return state
+        return _do_load(state, path)
+    return state
+
+
+def _do_load(state: State, path: str) -> State:
+    """Parse the image at `path` and replace the in-memory partition
+    plan with what the file says. On any parse error the previous
+    state is left intact and the error is surfaced in the status
+    bar -- never partial state."""
+    try:
+        loaded = atari_hd.load_image(path)
+    except atari_hd.ImageLoadError as e:
+        state.prompt_mode = PromptMode.OFF
+        state.status_message = f"load failed: {e}"
         state.dirty = True
         return state
+    except Exception as e:
+        state.prompt_mode = PromptMode.OFF
+        state.status_message = f"load failed (unexpected): {e}"
+        state.dirty = True
+        return state
+
+    state.image_path = path
+    state.format_id = loaded["format_id"]
+    state.strict_tos = loaded["strict_tos"]
+    state.partitions = list(loaded["partitions"])
+    state.selected_slot = 0
+    state.scroll_top = 0
+    state.unsaved_changes = False
+    state.prompt_mode = PromptMode.OFF
+    state.dirty = True
+
+    n = len(state.partitions)
+    msg = f"loaded {state.format_id}: {n} partition(s) from {path}"
+    if loaded.get("strict_tos_inferred"):
+        msg += (f"  [TOS<1.04: "
+                f"{'on' if state.strict_tos else 'off'} -- guessed]")
+    state.status_message = msg
     return state
 
 
@@ -698,7 +764,12 @@ def _preflight_check(state: State):
     real = [p for p in state.partitions if p is not None]
     if not real:
         return "no partitions to write"
+    min_mb = atari_hd.format_min_partition_mb(state.format_id)
     for i, part in enumerate(real):
+        if part.size_mb < min_mb:
+            return (f"partition {part.name!r} ({part.size_mb} MB) is "
+                    f"below the {min_mb} MB minimum for "
+                    f"{state.format_id}")
         ident = _effective_ident(state, i, part, state.format_id)
         cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
                                         ident)

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -2,33 +2,161 @@
 
 A single boring loop: read a key, mutate state, redraw on the dirty
 flag, repeat until exit_requested. No threads, no async, no signal
-handlers. See DECISIONS.md sections 3 and 4.
+handlers in this module (terminal.py owns SIGWINCH). See DECISIONS.md
+sections 3 and 4.
+
+Story 002 introduces inline-prompt sub-modes routed through their own
+dispatchers; the main-screen handler dispatches N / L / Q.
 """
 
+import os
 import sys
 
 from .input import Key, read_key
 from .render import render
-from .state import State
+from .state import PromptMode, State
 from .terminal import terminal_session
 
 
 def handle_key(state: State, key) -> State:
     """Dispatch one keypress into a state mutation. Returns the same
-    state object (mutated in place) for symmetry with future
-    immutable-state refactors -- callers must not assume identity is
-    preserved across calls."""
+    state (mutated in place) for symmetry with future immutable-state
+    refactors."""
+    # RESIZE always just triggers a redraw; nothing else.
+    if key == Key.RESIZE:
+        state.dirty = True
+        return state
+
+    if state.prompt_mode == PromptMode.OFF:
+        return _handle_main(state, key)
+    if state.prompt_mode in (PromptMode.ASK_NEW_PATH,
+                             PromptMode.ASK_LOAD_PATH):
+        return _handle_text_prompt(state, key)
+    if state.prompt_mode == PromptMode.CONFIRM_OVERWRITE:
+        return _handle_overwrite_confirm(state, key)
+    return state
+
+
+# -------------------------------------------------------------------
+# Main-screen handler
+# -------------------------------------------------------------------
+
+def _handle_main(state: State, key) -> State:
     if key in (Key.ESC, Key.CTRL_C):
+        # ESC at the main screen quits; story 006 will route through
+        # an unsaved-changes guard.
         state.exit_requested = True
         return state
-    if isinstance(key, str) and key.lower() == "q":
+    if not isinstance(key, str):
+        return state
+    k = key.lower()
+    if k == "q":
         state.exit_requested = True
+    elif k == "n":
+        state.prompt_mode = PromptMode.ASK_NEW_PATH
+        state.prompt_buffer = ""
+        state.status_message = None
+        state.dirty = True
+    elif k == "l":
+        state.prompt_mode = PromptMode.ASK_LOAD_PATH
+        state.prompt_buffer = ""
+        state.status_message = None
+        state.dirty = True
+    return state
+
+
+# -------------------------------------------------------------------
+# Text-prompt handlers (ASK_NEW_PATH / ASK_LOAD_PATH)
+# -------------------------------------------------------------------
+
+def _handle_text_prompt(state: State, key) -> State:
+    if key == Key.ESC:
+        # Cancel the prompt; clear buffer.
+        state.prompt_mode = PromptMode.OFF
+        state.prompt_buffer = ""
+        state.dirty = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    if key == Key.ENTER:
+        return _commit_text_prompt(state)
+    if key == Key.BACKSPACE:
+        if state.prompt_buffer:
+            state.prompt_buffer = state.prompt_buffer[:-1]
+            state.dirty = True
+        return state
+    if isinstance(key, str) and len(key) == 1 and key.isprintable():
+        state.prompt_buffer += key
+        state.dirty = True
+    return state
+
+
+def _commit_text_prompt(state: State) -> State:
+    path = state.prompt_buffer.strip()
+    mode = state.prompt_mode
+    if not path:
+        # Empty input -> just cancel quietly.
+        state.prompt_mode = PromptMode.OFF
+        state.prompt_buffer = ""
+        state.dirty = True
+        return state
+    state.prompt_buffer = ""
+    if mode == PromptMode.ASK_NEW_PATH:
+        if os.path.exists(path):
+            state.prompt_mode = PromptMode.CONFIRM_OVERWRITE
+            state.pending_path = path
+        else:
+            state.image_path = path
+            state.prompt_mode = PromptMode.OFF
+            state.status_message = None
+        state.dirty = True
+        return state
+    if mode == PromptMode.ASK_LOAD_PATH:
+        if not os.path.exists(path):
+            state.prompt_mode = PromptMode.OFF
+            state.status_message = f"file not found: {path}"
+        else:
+            # Story 007 will actually parse the file; until then we
+            # just remember the path and surface a placeholder note.
+            state.image_path = path
+            state.prompt_mode = PromptMode.OFF
+            state.status_message = "load not yet implemented (story 007)"
+        state.dirty = True
         return state
     return state
 
 
+# -------------------------------------------------------------------
+# Overwrite-confirm handler
+# -------------------------------------------------------------------
+
+def _handle_overwrite_confirm(state: State, key) -> State:
+    # Spec: 'O' (capital) confirms; anything else cancels.
+    if isinstance(key, str) and key == "O":
+        state.image_path = state.pending_path
+        state.pending_path = None
+        state.prompt_mode = PromptMode.OFF
+        state.status_message = None
+        state.dirty = True
+        return state
+    if key == Key.CTRL_C:
+        state.exit_requested = True
+        return state
+    # Anything else cancels -- including ESC, lowercase 'o',
+    # printable chars, and Enter.
+    state.pending_path = None
+    state.prompt_mode = PromptMode.OFF
+    state.status_message = "overwrite cancelled"
+    state.dirty = True
+    return state
+
+
+# -------------------------------------------------------------------
+# Main entry point
+# -------------------------------------------------------------------
+
 def main() -> int:
-    """Run the TUI. Returns a process exit code."""
     state = State()
     with terminal_session():
         while not state.exit_requested:

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -976,11 +976,18 @@ def _do_write(state: State) -> State:
         tmp.close()
 
         # Fresh Partition objects so plan_image's mutations
-        # (size_sectors / start_lba / etc.) don't leak back into our
-        # in-memory list.
+        # (size_sectors / start_lba / ebr_lba) don't leak back into our
+        # in-memory list. CRITICAL: is_extended must be carried over --
+        # it's the source of truth for the hybrid layout role and
+        # plan_image's validation rejects partitions whose size exceeds
+        # the wrong cap if we forget it (a >255 MB partition copied
+        # without is_extended=True would be planned as a primary and
+        # rejected at the 255 MB cap).
         plan_partitions = []
         for src in real_partitions:
-            new = atari_hd.Partition(name=src.name, size_mb=src.size_mb)
+            new = atari_hd.Partition(
+                name=src.name, size_mb=src.size_mb,
+                is_extended=getattr(src, "is_extended", False))
             # Preserve the user's explicit ident so XGM-chain logicals
             # render the right type if the user picked one. (Currently
             # ahdi_partition_id ignores this for XGM logicals; a

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -47,21 +47,81 @@ def _handle_main(state: State, key) -> State:
         # an unsaved-changes guard.
         state.exit_requested = True
         return state
+
+    # Navigation in the partition list. Hard-stop at top/bottom (no
+    # wrap) -- DECISIONS.md records the choice for consistency across
+    # every list in this epic.
+    if key in (Key.UP, Key.DOWN) or (isinstance(key, str)
+                                     and key in ("k", "j")):
+        return _handle_navigation(state, key)
+
     if not isinstance(key, str):
         return state
     k = key.lower()
     if k == "q":
         state.exit_requested = True
-    elif k == "n":
-        state.prompt_mode = PromptMode.ASK_NEW_PATH
-        state.prompt_buffer = ""
-        state.status_message = None
-        state.dirty = True
-    elif k == "l":
-        state.prompt_mode = PromptMode.ASK_LOAD_PATH
-        state.prompt_buffer = ""
-        state.status_message = None
-        state.dirty = True
+        return state
+
+    # File-management actions are only available before an image is
+    # loaded; once the user has an image, the keybindings switch to
+    # partition operations. Partition actions are stubs in this story
+    # -- story 004 (A/D/E/T) and story 006 (W) replace them with
+    # real handlers.
+    if state.image_path is None:
+        if k == "n":
+            state.prompt_mode = PromptMode.ASK_NEW_PATH
+            state.prompt_buffer = ""
+            state.status_message = None
+            state.dirty = True
+        elif k == "l":
+            state.prompt_mode = PromptMode.ASK_LOAD_PATH
+            state.prompt_buffer = ""
+            state.status_message = None
+            state.dirty = True
+        return state
+
+    return _handle_partition_action_stub(state, k)
+
+
+def _handle_navigation(state: State, key) -> State:
+    """Move selected_slot up/down in the partition list. Hard-stop at
+    bounds; ignored when the list is empty."""
+    if not state.partitions:
+        return state
+    if key == Key.UP or key == "k":
+        if state.selected_slot > 0:
+            state.selected_slot -= 1
+            state.dirty = True
+    elif key == Key.DOWN or key == "j":
+        if state.selected_slot < len(state.partitions) - 1:
+            state.selected_slot += 1
+            state.dirty = True
+    return state
+
+
+# Stubs surfaced for the partition-action keys until the real handlers
+# land (A/D/E/T in story 004, W in story 006). Status_message gives the
+# user feedback so we don't leave the screen looking dead.
+_STUB_MESSAGES = {
+    "a": "story 004 implements Add",
+    "d": "story 004 implements Delete",
+    "e": "story 004 implements Edit",
+    "t": "story 004 implements Type toggle",
+    "w": "story 006 implements Write",
+}
+
+
+def _handle_partition_action_stub(state: State, k: str) -> State:
+    if k not in _STUB_MESSAGES:
+        return state
+    # D / E / T / W require a non-empty list; A is always available
+    # (until 14-cap, which story 004 enforces). Match the dim/enable
+    # rule from the keybinding row.
+    requires_partition = k in ("d", "e", "t", "w")
+    if requires_partition and not state.partitions:
+        return state
+    state.status_message = _STUB_MESSAGES[k]
+    state.dirty = True
     return state
 
 

--- a/scripts/atari-hd/tui/app.py
+++ b/scripts/atari-hd/tui/app.py
@@ -477,7 +477,7 @@ def _find_violator_slots(state: State, candidate_format: str,
             continue
         ident = _effective_ident(state, i, part, candidate_format)
         cap = atari_hd.cap_mb_for_type(candidate_format, candidate_strict,
-                                        ident)
+                                        ident, slot_index=i)
         if part.size_mb > cap:
             violators.append(i)
     return violators
@@ -805,7 +805,7 @@ def _preflight_check(state: State):
                     f"{state.format_id}")
         ident = _effective_ident(state, i, part, state.format_id)
         cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
-                                        ident)
+                                        ident, slot_index=i)
         if part.size_mb > cap:
             return (f"partition {part.name!r} ({part.size_mb} MB) "
                     f"exceeds {cap} MB cap")

--- a/scripts/atari-hd/tui/input.py
+++ b/scripts/atari-hd/tui/input.py
@@ -1,0 +1,91 @@
+"""Single-key input.
+
+read_key() blocks until a key is available and returns either a
+sentinel from `Key` (for special keys like ESC, ENTER, CTRL_C) or a
+single-character string for printable input.
+
+Story 001 only needs ESC / CTRL_C / printable to drive the placeholder
+screen's quit handling. Arrow keys etc. arrive as ESC-sequences (Unix
++ Windows VT mode) or as 2-byte prefixed sequences (Windows pre-VT);
+this module *consumes* those sequences and returns Key.UNKNOWN so
+they do not trigger spurious exits, but does not decode them. Real
+arrow-key decoding is a story-002 concern.
+"""
+
+import os
+import sys
+from enum import Enum
+
+
+class Key(Enum):
+    """Special-key sentinels."""
+    ESC = "ESC"
+    CTRL_C = "CTRL_C"
+    ENTER = "ENTER"
+    UNKNOWN = "UNKNOWN"
+
+
+if os.name == "posix":
+    import select
+
+    def _has_pending(timeout: float = 0.0) -> bool:
+        r, _, _ = select.select([sys.stdin], [], [], timeout)
+        return bool(r)
+
+    def _drain():
+        while _has_pending(0.0):
+            os.read(sys.stdin.fileno(), 1)
+
+    def read_key():
+        b = os.read(sys.stdin.fileno(), 1)
+        if not b:
+            return Key.UNKNOWN
+        if b == b"\x1b":
+            # Could be a real ESC keypress or the start of an escape
+            # sequence (arrow keys, F-keys, etc.). Peek with a short
+            # timeout to disambiguate; if more bytes follow within
+            # 50 ms it's a sequence, drain and return UNKNOWN.
+            if _has_pending(0.05):
+                _drain()
+                return Key.UNKNOWN
+            return Key.ESC
+        if b == b"\x03":
+            return Key.CTRL_C
+        if b in (b"\r", b"\n"):
+            return Key.ENTER
+        try:
+            return b.decode("utf-8", errors="replace")
+        except Exception:
+            return Key.UNKNOWN
+
+elif os.name == "nt":
+    import msvcrt
+
+    def read_key():
+        b = msvcrt.getch()
+        # Pre-VT-style special keys arrive as a 2-byte prefix
+        # (\x00 or \xe0) followed by a key code. Drain the second
+        # byte; story 002 will decode them.
+        if b in (b"\x00", b"\xe0"):
+            msvcrt.getch()
+            return Key.UNKNOWN
+        if b == b"\x1b":
+            # In VT-input mode arrows arrive as ESC sequences. Peek
+            # for more bytes; if any are queued, drain and return
+            # UNKNOWN. If nothing follows it's a real ESC.
+            if msvcrt.kbhit():
+                while msvcrt.kbhit():
+                    msvcrt.getch()
+                return Key.UNKNOWN
+            return Key.ESC
+        if b == b"\x03":
+            return Key.CTRL_C
+        if b in (b"\r", b"\n"):
+            return Key.ENTER
+        try:
+            return b.decode("utf-8", errors="replace")
+        except Exception:
+            return Key.UNKNOWN
+
+else:
+    raise RuntimeError(f"unsupported platform: os.name={os.name!r}")

--- a/scripts/atari-hd/tui/input.py
+++ b/scripts/atari-hd/tui/input.py
@@ -22,7 +22,15 @@ class Key(Enum):
     ESC = "ESC"
     CTRL_C = "CTRL_C"
     ENTER = "ENTER"
+    BACKSPACE = "BACKSPACE"
+    RESIZE = "RESIZE"
     UNKNOWN = "UNKNOWN"
+
+
+# Set by the SIGWINCH handler installed in terminal.py (POSIX only).
+# read_key checks and clears it after an interrupted os.read; if set,
+# returns Key.RESIZE so the event loop can refresh the layout.
+resize_pending = False
 
 
 if os.name == "posix":
@@ -37,7 +45,19 @@ if os.name == "posix":
             os.read(sys.stdin.fileno(), 1)
 
     def read_key():
-        b = os.read(sys.stdin.fileno(), 1)
+        global resize_pending
+        while True:
+            try:
+                b = os.read(sys.stdin.fileno(), 1)
+                break
+            except InterruptedError:
+                # SIGWINCH fired during the read. If our handler set
+                # the resize flag, surface it to the event loop;
+                # otherwise retry the read.
+                if resize_pending:
+                    resize_pending = False
+                    return Key.RESIZE
+                continue
         if not b:
             return Key.UNKNOWN
         if b == b"\x1b":
@@ -53,6 +73,8 @@ if os.name == "posix":
             return Key.CTRL_C
         if b in (b"\r", b"\n"):
             return Key.ENTER
+        if b in (b"\x7f", b"\x08"):
+            return Key.BACKSPACE
         try:
             return b.decode("utf-8", errors="replace")
         except Exception:
@@ -82,6 +104,8 @@ elif os.name == "nt":
             return Key.CTRL_C
         if b in (b"\r", b"\n"):
             return Key.ENTER
+        if b in (b"\x7f", b"\x08"):
+            return Key.BACKSPACE
         try:
             return b.decode("utf-8", errors="replace")
         except Exception:

--- a/scripts/atari-hd/tui/input.py
+++ b/scripts/atari-hd/tui/input.py
@@ -24,7 +24,21 @@ class Key(Enum):
     ENTER = "ENTER"
     BACKSPACE = "BACKSPACE"
     RESIZE = "RESIZE"
+    UP = "UP"
+    DOWN = "DOWN"
+    LEFT = "LEFT"
+    RIGHT = "RIGHT"
     UNKNOWN = "UNKNOWN"
+
+
+# Mapping from VT-style arrow sequences (the byte after `\x1b[`) to
+# Key sentinels. Used by both POSIX and the VT path on Windows.
+_VT_ARROWS = {
+    b"A": Key.UP,
+    b"B": Key.DOWN,
+    b"C": Key.RIGHT,
+    b"D": Key.LEFT,
+}
 
 
 # Set by the SIGWINCH handler installed in terminal.py (POSIX only).
@@ -63,10 +77,19 @@ if os.name == "posix":
         if b == b"\x1b":
             # Could be a real ESC keypress or the start of an escape
             # sequence (arrow keys, F-keys, etc.). Peek with a short
-            # timeout to disambiguate; if more bytes follow within
-            # 50 ms it's a sequence, drain and return UNKNOWN.
+            # timeout to disambiguate.
             if _has_pending(0.05):
-                _drain()
+                # Read the rest of the sequence. We expect short
+                # CSI-style sequences (`[A` etc.) but bound the read
+                # to be safe against runaway terminals.
+                seq = b""
+                for _ in range(16):
+                    if not _has_pending(0.05):
+                        break
+                    seq += os.read(sys.stdin.fileno(), 1)
+                # Match arrow keys: `[A` / `[B` / `[C` / `[D`.
+                if len(seq) == 2 and seq[:1] == b"[" and seq[1:2] in _VT_ARROWS:
+                    return _VT_ARROWS[seq[1:2]]
                 return Key.UNKNOWN
             return Key.ESC
         if b == b"\x03":
@@ -83,21 +106,30 @@ if os.name == "posix":
 elif os.name == "nt":
     import msvcrt
 
+    # Pre-VT special-key codes (Windows console, second byte after the
+    # 0x00 / 0xE0 prefix).
+    _WIN_PREVT_ARROWS = {
+        b"H": Key.UP,
+        b"P": Key.DOWN,
+        b"M": Key.RIGHT,
+        b"K": Key.LEFT,
+    }
+
     def read_key():
         b = msvcrt.getch()
         # Pre-VT-style special keys arrive as a 2-byte prefix
-        # (\x00 or \xe0) followed by a key code. Drain the second
-        # byte; story 002 will decode them.
+        # (\x00 or \xe0) followed by a key code.
         if b in (b"\x00", b"\xe0"):
-            msvcrt.getch()
-            return Key.UNKNOWN
+            b2 = msvcrt.getch()
+            return _WIN_PREVT_ARROWS.get(b2, Key.UNKNOWN)
         if b == b"\x1b":
-            # In VT-input mode arrows arrive as ESC sequences. Peek
-            # for more bytes; if any are queued, drain and return
-            # UNKNOWN. If nothing follows it's a real ESC.
+            # In VT-input mode arrows arrive as ESC sequences.
             if msvcrt.kbhit():
+                seq = b""
                 while msvcrt.kbhit():
-                    msvcrt.getch()
+                    seq += msvcrt.getch()
+                if len(seq) == 2 and seq[:1] == b"[" and seq[1:2] in _VT_ARROWS:
+                    return _VT_ARROWS[seq[1:2]]
                 return Key.UNKNOWN
             return Key.ESC
         if b == b"\x03":

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -228,8 +228,9 @@ def _partition_ident(part, index: int, format_id: str) -> str:
     `ahdi_ident` attribute when story 004 starts setting one; otherwise
     derives a v1 value from the format and slot index.
 
-    For AHDI: slot 0 is forced GEM (boot rule); later slots flip to BGM
-    above the 32 MB threshold.
+    For AHDI: slot 0 is clamped to GEM (legacy-driver compatibility
+    default; see atari_hd.ahdi_partition_id() for the rationale);
+    later slots flip to BGM above the 32 MB threshold.
     For PPDRIVER / HDDRIVER: every partition is FAT16 in the MBR table
     (the EBR-chain "extended" type is the chain header, not a partition
     the user listed).
@@ -345,6 +346,10 @@ def _format_prompt_or_message(state: State, cols: int) -> str:
         verb = "violates" if n == 1 else "violate"
         return (f"{n} partition{plural} {verb} the new format's "
                 "rules. Discard? (y/N)")
+    if state.prompt_mode == PromptMode.CONFIRM_OVERWRITE_WRITE:
+        return f"Overwrite {state.image_path}? (y/N)"
+    if state.prompt_mode == PromptMode.CONFIRM_DISCARD_UNSAVED:
+        return "Discard unsaved changes? (y/N)"
     if state.status_message:
         return state.status_message
     return ""

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -158,16 +158,24 @@ def _display_start_lbas(state: State) -> list:
     """Return [start_lba_i] for each slot in `state.partitions` for the
     "Start (LBA)" column.
 
-    `Partition.start_lba` is only populated by `plan_image()` at write
-    time, so partitions added in the dialog show 0 until the user hits
-    W. We mirror plan_image's sequential placement here so the list
-    reflects something useful while the user is still composing.
+    Two cases:
 
-    Approximate, not authoritative -- we don't account for the EBR/XGM
-    chain overhead that plan_image inserts (a sector or two before each
-    logical when N exceeds the format's primary-slot count). Slots that
-    are None (a hole left by Delete) get 0 and don't advance the
-    cursor, matching plan_image which skips them entirely.
+    1. `Partition.start_lba` is already populated -- e.g. the plan
+       came from `load_image()` so each partition carries its real
+       on-disk LBA. Use it verbatim. This is the only way to display
+       the correct data-start LBA for chain logicals: the cumulative
+       sum below would land on the EBR sector itself (start_of_data
+       minus 1) because it doesn't account for EBR / XGM chain
+       overhead.
+
+    2. `start_lba == 0` -- the partition was added in the dialog and
+       hasn't been planned yet. Fall back to a sequential approximation
+       so the list reflects something useful while composing. Still
+       approximate (no chain overhead), but plan_image rewrites
+       start_lba on write, so the discrepancy resolves itself.
+
+    Slots that are None (a hole left by Delete) get 0 and don't
+    advance the cursor, matching plan_image which skips them entirely.
     """
     if not state.partitions:
         return []
@@ -176,6 +184,11 @@ def _display_start_lbas(state: State) -> list:
     for part in state.partitions:
         if part is None:
             out.append(0)
+            continue
+        if part.start_lba > 0:
+            out.append(part.start_lba)
+            next_lba = part.start_lba + (part.size_sectors
+                                          or (part.size_mb * 1024 * 1024) // 512)
             continue
         out.append(next_lba)
         size_sectors = (part.size_mb * 1024 * 1024) // 512

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -1,16 +1,17 @@
 """Pure rendering: state -> frame string with embedded ANSI escapes.
 
-Each public function in this module takes a State and returns a string
-that, when written to stdout, produces a complete fresh frame. No
-incremental diffing; we redraw the whole screen on every dirty flag.
-At our screen sizes (80x24+) this is not measurable.
+Each call returns a complete fresh frame; we don't diff. At our screen
+sizes (80x24+) writing the whole screen on every dirty flag is not
+measurable and the implementation stays simple.
 
-Story 001 only renders the PLACEHOLDER screen. Stories 002-008 add
-the real screens; each gets its own _render_<name> private function
-and is dispatched by render() based on state.screen.
+Story 002 lands the three-region main screen (header / body /
+status bar) plus the "terminal too small" fallback. Stories 003+
+extend the body and the keybinding list.
 """
 
-from .state import Screen, State
+import shutil
+
+from .state import PromptMode, Screen, State
 
 
 # ANSI escape sequences shared across screens.
@@ -18,22 +19,148 @@ CLEAR_SCREEN = "\x1b[2J"
 CURSOR_HOME = "\x1b[H"
 
 
+# Hard floor on terminal size. Below either dimension the layout
+# breaks; we surface "terminal too small" instead of trying to
+# graceful-degrade.
+MIN_COLS = 80
+MIN_ROWS = 24
+
+
+# Box-drawing characters. UTF-8 only -- DECISIONS.md accepts this on
+# all three target terminals (Terminal.app / iTerm2 / Windows
+# Terminal / modern Linux terminals).
+HLINE = "─"   # ─
+
+
 def render(state: State) -> str:
-    """Return a complete frame string for the current screen."""
-    if state.screen == Screen.PLACEHOLDER:
-        return _render_placeholder(state)
+    """Return a complete frame string for the current screen, sized to
+    the live terminal."""
+    cols, rows = shutil.get_terminal_size((MIN_COLS, MIN_ROWS))
+    if cols < MIN_COLS or rows < MIN_ROWS:
+        return _render_too_small(cols, rows)
+    if state.screen == Screen.MAIN:
+        return _render_main(state, cols, rows)
     raise ValueError(f"unknown screen: {state.screen!r}")
 
 
-def _render_placeholder(state: State) -> str:
-    return (
-        CLEAR_SCREEN
-        + CURSOR_HOME
-        + "SidecarTridge atari-hd image creator (TUI)\r\n"
-        + "\r\n"
-        + "  Skeleton -- epic-003 / story 001\r\n"
-        + "\r\n"
-        + "  Real screens land in stories 002-008.\r\n"
-        + "\r\n"
-        + "  Press q, Esc, or Ctrl-C to quit.\r\n"
-    )
+def _render_too_small(cols: int, rows: int) -> str:
+    msg1 = "Terminal too small."
+    msg2 = f"Need at least {MIN_COLS}x{MIN_ROWS}; got {cols}x{rows}."
+    msg3 = "Resize, or press q / Ctrl-C to quit."
+    return CLEAR_SCREEN + CURSOR_HOME + "\r\n".join((msg1, msg2, "", msg3)) + "\r\n"
+
+
+def _render_main(state: State, cols: int, rows: int) -> str:
+    # Layout (24-row baseline; expands at the body for taller terminals):
+    #   row 1:        header line
+    #   row 2:        separator
+    #   rows 3..N-3:  body (placeholder for now; partition list in 003)
+    #   row N-2:      separator
+    #   row N-1:      key bindings
+    #   row N:        prompt or transient status message
+    body_rows = rows - 4  # header + 2 separators + status keys row
+    # Status occupies 2 rows (keys + prompt/message); we already
+    # reserved one of those by counting "rows - 4" above. Reserve one
+    # more by trimming body_rows.
+    body_rows -= 1
+
+    parts = [CLEAR_SCREEN, CURSOR_HOME,
+             _render_header(state, cols), "\r\n",
+             _hline(cols), "\r\n",
+             _render_body(state, cols, body_rows),
+             _hline(cols), "\r\n",
+             _render_status_keys(cols), "\r\n",
+             _render_status_message(state, cols)]
+    return "".join(parts)
+
+
+def _hline(cols: int) -> str:
+    return HLINE * cols
+
+
+def _render_header(state: State, cols: int) -> str:
+    left = "atari-hd image creator"
+    if state.image_path is None:
+        right = "(no image)"
+    else:
+        right = f"image: {state.image_path}"
+    # Left + right with a 2-space minimum gap; truncate the right
+    # half (which is the path) when there isn't room.
+    gap = 2
+    available_for_right = cols - len(left) - gap
+    if available_for_right < len(right):
+        right = _truncate_middle(right, max(available_for_right, 5))
+    pad = cols - len(left) - len(right)
+    if pad < 0:
+        # left too long for cols (shouldn't happen at 80+ cols, but be
+        # defensive); just hard-truncate.
+        return (left + " " + right)[:cols]
+    return left + (" " * pad) + right
+
+
+def _render_body(state: State, cols: int, height: int) -> str:
+    """Render the partition-list area. Story 002 leaves it as a
+    centered hint; story 003 fills it with the real list."""
+    if state.image_path is None:
+        msg = "No image selected. Press N to create one or L to load an existing image."
+    else:
+        msg = "(partition list -- story 003 fills this in)"
+    msg = _truncate_middle(msg, cols - 2)
+
+    lines = []
+    # Show the message centered on the middle row of the body. All
+    # other body rows are empty (full-width to overwrite anything from
+    # a previous larger frame).
+    middle = height // 2
+    blank = " " * cols
+    for i in range(height):
+        if i == middle:
+            pad_left = max(0, (cols - len(msg)) // 2)
+            line = (" " * pad_left) + msg
+            line += " " * max(0, cols - len(line))
+            lines.append(line[:cols])
+        else:
+            lines.append(blank)
+    return "\r\n".join(lines) + "\r\n"
+
+
+def _render_status_keys(cols: int) -> str:
+    keys = "N=New   L=Load   Q=Quit"
+    if len(keys) > cols:
+        return keys[:cols]
+    return keys + (" " * (cols - len(keys)))
+
+
+def _render_status_message(state: State, cols: int) -> str:
+    """Bottom row: either a prompt (when prompt_mode is active) or a
+    transient status message, or blank."""
+    line = _format_prompt_or_message(state, cols)
+    if len(line) > cols:
+        line = line[:cols]
+    return line + (" " * (cols - len(line)))
+
+
+def _format_prompt_or_message(state: State, cols: int) -> str:
+    if state.prompt_mode == PromptMode.ASK_NEW_PATH:
+        return f"New image filename: {state.prompt_buffer}_"
+    if state.prompt_mode == PromptMode.ASK_LOAD_PATH:
+        return f"Load image filename: {state.prompt_buffer}_"
+    if state.prompt_mode == PromptMode.CONFIRM_OVERWRITE:
+        path = state.pending_path or "(unknown)"
+        return (f"{path} exists. Press O to overwrite, "
+                "anything else to cancel.")
+    if state.status_message:
+        return state.status_message
+    return ""
+
+
+def _truncate_middle(s: str, max_width: int) -> str:
+    """Shorten `s` to fit within `max_width` using a "...".  separator
+    in the middle. For very short widths just hard-truncate."""
+    if len(s) <= max_width:
+        return s
+    if max_width < 5:
+        return s[:max_width]
+    head = (max_width - 3) // 2
+    tail = max_width - 3 - head
+    return s[:head] + "..." + s[-tail:]

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -268,12 +268,11 @@ def _render_partition_row(part, index: int, cols: int,
 
 def _partition_ident(part, index: int, format_id: str) -> str:
     """Best-effort short ident for the type column. Honors an explicit
-    `ahdi_ident` attribute when story 004 starts setting one; otherwise
-    derives a v1 value from the format and slot index.
+    `ahdi_ident` attribute when set; otherwise derives the value the
+    writer will emit by mirroring atari_hd.ahdi_partition_id() (ident
+    follows bps strictly: GEM iff bps=512, i.e. size <= 31 MB; BGM
+    otherwise).
 
-    For AHDI: slot 0 is clamped to GEM (legacy-driver compatibility
-    default; see atari_hd.ahdi_partition_id() for the rationale);
-    later slots flip to BGM above the 32 MB threshold.
     For PPDRIVER / HDDRIVER: every partition is FAT16 in the MBR table
     (the EBR-chain "extended" type is the chain header, not a partition
     the user listed).
@@ -283,9 +282,7 @@ def _partition_ident(part, index: int, format_id: str) -> str:
         return explicit if isinstance(explicit, str) else explicit.decode(
             "ascii", errors="replace")
     if format_id == "AHDI":
-        if index == 0:
-            return "GEM"
-        return "GEM" if part.size_mb <= 32 else "BGM"
+        return "GEM" if part.size_mb <= atari_hd.AHDI_GEM_MAX_MB else "BGM"
     return "FAT16"
 
 
@@ -607,6 +604,16 @@ def validate_edit_dialog(state: State):
     if size_mb < min_mb:
         return (f"size below {min_mb} MB minimum for "
                 f"{state.format_id} hybrid layout")
+    # AHDI ident strictly follows bps: GEM iff bps=512, BGM iff bps>512.
+    # bps doubles past 31 MB (clusters_at_spc=2 > 32765), so a user
+    # picking BGM with size <= 31 MB would write ident=BGM but bps=512
+    # in the BPB -- the malformed combination flagged by AHDI 3.0.
+    # Reject explicitly so the user gets a clear message instead of a
+    # surprise ident swap at write time.
+    if (state.format_id == "AHDI" and d.type_choice == "BGM"
+            and size_mb <= atari_hd.AHDI_GEM_MAX_MB):
+        return (f"BGM requires size > {atari_hd.AHDI_GEM_MAX_MB} MB "
+                "(smaller partitions are GEM); pick GEM or grow the size")
     if size_mb > cap:
         kind = (f"GEM under {'TOS<1.04' if state.strict_tos else 'TOS 1.04+'}"
                 if state.format_id == "AHDI" and d.type_choice == "GEM"

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -59,6 +59,10 @@ def render(state: State) -> str:
         frame = _render_main(state, cols, rows)
         if state.edit_dialog is not None:
             frame += _render_edit_dialog_overlay(state, cols, rows)
+        # Help overlay sits on top of everything (story 008): drawn
+        # last so it covers the edit dialog and the main body.
+        if state.show_help:
+            frame += _render_help_overlay(state, cols, rows)
         return frame
     raise ValueError(f"unknown screen: {state.screen!r}")
 
@@ -329,7 +333,10 @@ def _render_status_keys(state: State, cols: int) -> str:
          so the user can pick the format before adding partitions.
     """
     if state.image_path is None:
-        line = "N=New   L=Load   Q=Quit"
+        # ? is universal but easy to miss; advertise it on the
+        # landing row where there's still space. The partition-list
+        # row is at the 80-col budget and stays as-is.
+        line = "N=New   L=Load   Q=Quit   ?=Help"
         return _pad_to(line, cols)
     # File actions stay visible even after an image is loaded so the
     # user can create a fresh plan or load a different file mid-session
@@ -618,3 +625,77 @@ def validate_edit_dialog(state: State):
             return f"label has illegal character: {ch!r}"
 
     return None
+
+
+# -------------------------------------------------------------------
+# Help overlay (story 008)
+# -------------------------------------------------------------------
+
+# Single source of truth for keybindings. Entries are
+# (group, key, description) tuples; the overlay walks them in order
+# and emits a group header row whenever the group changes. Tests and
+# any future docs should reference this list rather than maintain a
+# parallel copy.
+#
+# Sized to fit 80x24: 17 entries + 4 group headers + 2 borders = 23
+# rows, leaving 1 row of breathing space.
+HELP_ENTRIES = [
+    ("Files / Quit", "N",                "New image"),
+    ("Files / Quit", "L",                "Load image"),
+    ("Files / Quit", "Q",                "Quit (warns if unsaved)"),
+    ("Partitions",   "Up / Dn / k / j",  "Move selection"),
+    ("Partitions",   "A",                "Add partition"),
+    ("Partitions",   "D",                "Delete selected"),
+    ("Partitions",   "E",                "Edit selected"),
+    ("Partitions",   "T",                "Toggle GEM/BGM (AHDI)"),
+    ("Partitions",   "F",                "Change format"),
+    ("Partitions",   "W",                "Write image"),
+    ("Dialogs",      "Tab",              "Next field"),
+    ("Dialogs",      "t / Left / Right", "Cycle Type"),
+    ("Dialogs",      "Enter / S",        "Save"),
+    ("Dialogs",      "A / P / H",        "Pick format (in selector)"),
+    ("Dialogs",      "y / N / O",        "Confirm prompts (O = overwrite)"),
+    ("Dialogs",      "Esc",              "Cancel dialog / prompt"),
+    ("Anywhere",     "?",                "Toggle this help"),
+]
+
+HELP_BOX_WIDTH = 60
+HELP_KEY_COL = 18  # left-padded width of the key column inside rows
+
+
+def _render_help_overlay(state: State, cols: int, rows: int) -> str:
+    """Centered modal help overlay. Walks HELP_ENTRIES and emits a
+    group header on each transition; rows are key + description in
+    two aligned columns (per the story spec). ASCII content only --
+    box-drawing borders are the only non-ASCII pieces."""
+    body_lines = []
+    last_group = None
+    for group, key, desc in HELP_ENTRIES:
+        if group != last_group:
+            body_lines.append(group)
+            last_group = group
+        # Two columns: "  KEY<padded>  DESC". Indent group entries by
+        # 2 chars so the header (no indent) reads as a section break.
+        row = f"  {key.ljust(HELP_KEY_COL)}{desc}"
+        body_lines.append(row)
+
+    inner = HELP_BOX_WIDTH - 2  # subtract the side borders
+    height = len(body_lines) + 2  # +2 for top/bottom borders
+    box_top = max(1, (rows - height) // 2 + 1)
+    box_left = max(1, (cols - HELP_BOX_WIDTH) // 2 + 1)
+
+    title = " atari-hd help (Esc / ? to close) "
+    title_pad = max(0, inner - len(title))
+    left_pad = title_pad // 2
+    right_pad = title_pad - left_pad
+    top_border = "┌" + ("─" * left_pad) + title + ("─" * right_pad) + "┐"
+    bottom_border = "└" + ("─" * inner) + "┘"
+
+    out = [_cursor_to(box_top, box_left) + top_border]
+    for i, body in enumerate(body_lines):
+        if len(body) > inner:
+            body = body[:inner]
+        line = "│" + body + (" " * (inner - len(body))) + "│"
+        out.append(_cursor_to(box_top + 1 + i, box_left) + line)
+    out.append(_cursor_to(box_top + height - 1, box_left) + bottom_border)
+    return "".join(out)

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -39,9 +39,11 @@ MIN_ROWS = 24
 HLINE = "─"   # ─
 
 
-# Partition-list column widths, in order.
+# Partition-list column widths, in order. COL_TYPE = 6 fits "FAT16+"
+# (the trailing "+" marks chain logicals; bare "FAT16" / "GEM" / "BGM"
+# / "XGM" mean primary).
 COL_SLOT = 4
-COL_TYPE = 5
+COL_TYPE = 6
 COL_START = 12
 COL_SIZE = 10
 COL_LABEL = 13
@@ -286,17 +288,24 @@ def _partition_ident(part, index: int, format_id: str) -> str:
     follows bps strictly: GEM iff bps=512, i.e. size <= 31 MB; BGM
     otherwise).
 
-    For PPDRIVER / HDDRIVER: every partition is FAT16 in the MBR table
-    (the EBR-chain "extended" type is the chain header, not a partition
-    the user listed).
+    For PPDRIVER / HDDRIVER: every partition is FAT16 in the MBR table.
+
+    A trailing "+" marks chain logicals (those whose ebr_lba > 0 --
+    set by load_image / plan_image when the partition lives inside an
+    EBR chain on hybrid formats or an XGM chain on AHDI). Bare idents
+    mean the partition occupies a primary slot.
     """
     explicit = getattr(part, "ahdi_ident", None)
     if explicit is not None:
-        return explicit if isinstance(explicit, str) else explicit.decode(
+        ident = explicit if isinstance(explicit, str) else explicit.decode(
             "ascii", errors="replace")
-    if format_id == "AHDI":
-        return "GEM" if part.size_mb <= atari_hd.AHDI_GEM_MAX_MB else "BGM"
-    return "FAT16"
+    elif format_id == "AHDI":
+        ident = "GEM" if part.size_mb <= atari_hd.AHDI_GEM_MAX_MB else "BGM"
+    else:
+        ident = "FAT16"
+    if getattr(part, "ebr_lba", 0):
+        ident += "+"
+    return ident
 
 
 def _format_size(mb: int) -> str:

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -156,6 +156,54 @@ def _render_body_empty_partitions(state: State, cols: int, height: int) -> str:
     return "\r\n".join(lines) + "\r\n"
 
 
+def _effective_kind(state: State, d) -> str:
+    """Resolve the partition kind ("primary" / "extended") that the
+    open dialog will commit. Slot 0 is always primary; HDDRIVER slot
+    >= 1 is always extended; PPDRIVER slot >= 1 honors the user's
+    d.kind_choice. AHDI partitions fall through to "primary" (the AHDI
+    side derives primary/extended from N at write time)."""
+    if d.slot == 0:
+        return "primary"
+    if state.format_id == "HDDRIVER":
+        return "extended"
+    if state.format_id == "PPDRIVER":
+        return d.kind_choice
+    return "primary"
+
+
+def _kind_cap_mb(state: State, d, primary_count: int) -> int:
+    """Cap (MB) for the partition the dialog is composing, derived from
+    the effective kind (primary -> HYBRID_PRIMARY_MAX_MB; extended ->
+    HYBRID_MAX_PARTITION_MB) on hybrid formats. AHDI defers to
+    cap_mb_for_type's ident-based logic."""
+    is_hybrid = state.format_id in ("PPDRIVER", "HDDRIVER")
+    if is_hybrid:
+        kind = _effective_kind(state, d)
+        if kind == "primary":
+            return atari_hd.HYBRID_PRIMARY_MAX_MB
+        return atari_hd.HYBRID_MAX_PARTITION_MB
+    return atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
+                                     d.type_choice, slot_index=d.slot,
+                                     primary_count=primary_count)
+
+
+def _dialog_primary_count(state: State, d) -> int:
+    """primary_count for partition_layout from the perspective of the
+    open edit dialog. ADD adds a slot to the count (the partition the
+    user is about to commit); EDIT leaves it unchanged. Used by both
+    the dialog's live cap label and validate_edit_dialog so the
+    primary-vs-logical decision matches what plan_image will produce
+    on save."""
+    n = sum(1 for p in state.partitions if p is not None)
+    if d.mode == EditMode.ADD:
+        n += 1
+    if n < 1:
+        n = 1
+    if n > 14:
+        n = 14
+    return atari_hd.partition_layout(state.format_id, n)["primary_count"]
+
+
 def _display_start_lbas(state: State) -> list:
     """Return [start_lba_i] for each slot in `state.partitions` for the
     "Start (LBA)" column.
@@ -470,7 +518,7 @@ def _truncate_middle(s: str, max_width: int) -> str:
 # -------------------------------------------------------------------
 
 DIALOG_WIDTH = 56
-DIALOG_HEIGHT = 13
+DIALOG_HEIGHT = 14
 
 
 def _render_edit_dialog_overlay(state: State, cols: int, rows: int) -> str:
@@ -482,8 +530,28 @@ def _render_edit_dialog_overlay(state: State, cols: int, rows: int) -> str:
     box_left = max(1, (cols - DIALOG_WIDTH) // 2 + 1)
 
     title = "Add Partition" if d.mode == EditMode.ADD else f"Edit Partition #{d.slot}"
-    cap_mb = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
-                                       d.type_choice, slot_index=d.slot)
+    primary_count = _dialog_primary_count(state, d)
+    is_hybrid = state.format_id in ("PPDRIVER", "HDDRIVER")
+
+    # Kind row (hybrid only): primary vs extended. Slot 0 is locked
+    # primary; HDDRIVER slot >= 1 is locked extended; PPDRIVER slot >= 1
+    # is the user's free choice.
+    kind_visible = is_hybrid
+    kind_locked = is_hybrid and (d.slot == 0
+                                  or state.format_id == "HDDRIVER")
+    kind_value = ""
+    if kind_visible:
+        if kind_locked:
+            forced = ("primary" if d.slot == 0 else "extended")
+            kind_value = f"{forced} (locked)"
+        else:
+            pri = "[Primary]" if d.kind_choice == "primary" else " Primary "
+            ext = "[Extended]" if d.kind_choice == "extended" else " Extended "
+            kind_value = f"{pri}  {ext}"
+        if d.field == EditField.KIND and not kind_locked:
+            kind_value = INVERSE_ON + kind_value + INVERSE_OFF
+
+    cap_mb = _kind_cap_mb(state, d, primary_count)
     min_mb = atari_hd.format_min_partition_mb(state.format_id)
     if min_mb > 1:
         # Hybrid formats have a hard 32 MB floor; surface the range
@@ -524,8 +592,10 @@ def _render_edit_dialog_overlay(state: State, cols: int, rows: int) -> str:
     body_lines = [
         title.ljust(inner),
         "",
-        f"  {size_label.ljust(20)} {size_value}",
     ]
+    if kind_visible:
+        body_lines.append(f"  {'Kind:'.ljust(20)} {kind_value}")
+    body_lines.append(f"  {size_label.ljust(20)} {size_value}")
     if type_visible:
         body_lines.append(f"  {'Type:'.ljust(20)} {type_value}")
     body_lines.append(f"  {'Label:'.ljust(20)} {label_value}")
@@ -533,7 +603,7 @@ def _render_edit_dialog_overlay(state: State, cols: int, rows: int) -> str:
     body_lines.append(_truncate_middle(f"Status: {status_line}", inner))
     body_lines.append("")
     body_lines.append(_truncate_middle(
-        "[Tab] field  [t] type  [Enter] save  [Esc] cancel", inner))
+        "[Tab] field  [t] cycle  [Enter] save  [Esc] cancel", inner))
 
     # Pad body to DIALOG_HEIGHT - 2 (top + bottom border rows).
     while len(body_lines) < DIALOG_HEIGHT - 2:
@@ -616,13 +686,15 @@ def validate_edit_dialog(state: State):
     if size_mb < 1:
         return "size must be >= 1 MB"
 
-    # Cap depends on the user-chosen type AND the slot index. For
-    # AHDI slot 0 the dialog locks type to GEM (=> GEM cap); for
-    # hybrid slot 0 the primary cap (255 MB) applies because real
-    # PPDRIVER / HDDRIVER on Atari hardware reject primaries with
-    # bps>4096; for slot >= 1 the BGM / hybrid ceiling applies.
-    cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
-                                    d.type_choice, slot_index=d.slot)
+    # Cap depends on:
+    #  - For AHDI: ident (GEM cap vs BGM cap) and strict_tos.
+    #  - For hybrid: the resolved Kind (primary -> 255 MB; extended
+    #    -> 511 MB), ignoring d.type_choice (AHDI ident doesn't apply
+    #    to hybrid). The kind comes from _effective_kind which honours
+    #    slot 0 / HDDRIVER locks and the user's d.kind_choice on
+    #    PPDRIVER slot >= 1.
+    primary_count = _dialog_primary_count(state, d)
+    cap = _kind_cap_mb(state, d, primary_count)
     min_mb = atari_hd.format_min_partition_mb(state.format_id)
     if size_mb < min_mb:
         return (f"size below {min_mb} MB minimum for "
@@ -642,11 +714,48 @@ def validate_edit_dialog(state: State):
             kind = f"GEM under {'TOS<1.04' if state.strict_tos else 'TOS 1.04+'}"
         elif state.format_id == "AHDI":
             kind = "BGM"
-        elif d.slot == 0:
+        elif _effective_kind(state, d) == "primary":
             kind = f"{state.format_id} primary (bps must stay <= 4096)"
         else:
-            kind = f"{state.format_id} logical"
+            kind = f"{state.format_id} extended"
         return f"size exceeds {cap} MB cap for {kind}"
+
+    # Hybrid layout rules -- surface here so the user sees the error
+    # while composing instead of at W. plan_image enforces the same
+    # rules at write time as a backstop.
+    if state.format_id in ("PPDRIVER", "HDDRIVER"):
+        kind = _effective_kind(state, d)
+        # Slot 0 must be primary -- already locked in the dialog, but
+        # check defensively.
+        if d.slot == 0 and kind != "primary":
+            return "first partition must be a primary"
+        # No primary may follow an extended partition.
+        if kind == "primary":
+            for i, prior in enumerate(state.partitions):
+                if i >= d.slot:
+                    break
+                if prior is None:
+                    continue
+                if prior.is_extended:
+                    return (f"slot {i} is extended; primaries must "
+                            "come before any extended partitions")
+        # Total primary count after this commit must not exceed the
+        # format's max.
+        if kind == "primary":
+            max_p = atari_hd.MAX_PRIMARY_PARTITIONS[state.format_id]
+            n = max(len(state.partitions), d.slot + 1)
+            primaries = 0
+            for i in range(n):
+                if i == d.slot:
+                    primaries += 1
+                    continue
+                p = (state.partitions[i]
+                      if i < len(state.partitions) else None)
+                if p is not None and not p.is_extended:
+                    primaries += 1
+            if primaries > max_p:
+                return (f"{state.format_id} allows at most {max_p} "
+                        f"primary partition(s); make this one extended")
 
     # Label validation -- empty is OK (we'll default to a generated
     # name on commit), otherwise must be uppercase ASCII per the

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -461,7 +461,7 @@ def _render_edit_dialog_overlay(state: State, cols: int, rows: int) -> str:
 
     title = "Add Partition" if d.mode == EditMode.ADD else f"Edit Partition #{d.slot}"
     cap_mb = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
-                                       d.type_choice)
+                                       d.type_choice, slot_index=d.slot)
     min_mb = atari_hd.format_min_partition_mb(state.format_id)
     if min_mb > 1:
         # Hybrid formats have a hard 32 MB floor; surface the range
@@ -594,12 +594,13 @@ def validate_edit_dialog(state: State):
     if size_mb < 1:
         return "size must be >= 1 MB"
 
-    # Cap depends on the user-chosen type via cap_mb_for_type. For
-    # AHDI slot 0 the dialog locks type to GEM, so cap is the GEM
-    # cap; for hybrid formats type is moot and the cap is the
-    # hybrid TOS-NSECTS ceiling.
+    # Cap depends on the user-chosen type AND the slot index. For
+    # AHDI slot 0 the dialog locks type to GEM (=> GEM cap); for
+    # hybrid slot 0 the primary cap (255 MB) applies because real
+    # PPDRIVER / HDDRIVER on Atari hardware reject primaries with
+    # bps>4096; for slot >= 1 the BGM / hybrid ceiling applies.
     cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
-                                    d.type_choice)
+                                    d.type_choice, slot_index=d.slot)
     min_mb = atari_hd.format_min_partition_mb(state.format_id)
     if size_mb < min_mb:
         return (f"size below {min_mb} MB minimum for "
@@ -615,10 +616,14 @@ def validate_edit_dialog(state: State):
         return (f"BGM requires size > {atari_hd.AHDI_GEM_MAX_MB} MB "
                 "(smaller partitions are GEM); pick GEM or grow the size")
     if size_mb > cap:
-        kind = (f"GEM under {'TOS<1.04' if state.strict_tos else 'TOS 1.04+'}"
-                if state.format_id == "AHDI" and d.type_choice == "GEM"
-                else "BGM" if state.format_id == "AHDI"
-                else f"{state.format_id} hybrid")
+        if state.format_id == "AHDI" and d.type_choice == "GEM":
+            kind = f"GEM under {'TOS<1.04' if state.strict_tos else 'TOS 1.04+'}"
+        elif state.format_id == "AHDI":
+            kind = "BGM"
+        elif d.slot == 0:
+            kind = f"{state.format_id} primary (bps must stay <= 4096)"
+        else:
+            kind = f"{state.format_id} logical"
         return f"size exceeds {cap} MB cap for {kind}"
 
     # Label validation -- empty is OK (we'll default to a generated

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -282,9 +282,11 @@ def _selected_is_real(state: State) -> bool:
 def _render_status_keys(state: State, cols: int) -> str:
     """Keybinding row. Morphs by state:
        - no image: file actions (N=New L=Load Q=Quit)
-       - image set: partition actions (A/D/E/T/W/Q), with D/E/T
+       - image set: partition actions (A/D/E/T/W/F/Q), with D/E/T
          dimmed when the selected slot is empty (no real partition
          to act on); W dimmed when there are zero real partitions.
+         F (format selector) is always enabled when an image is set
+         so the user can pick the format before adding partitions.
     """
     if state.image_path is None:
         line = "N=New   L=Load   Q=Quit"
@@ -300,6 +302,7 @@ def _render_status_keys(state: State, cols: int) -> str:
     ]
     for label, enabled in cond:
         items.append(label if enabled else f"{DIM_ON}{label}{DIM_OFF}")
+    items.append("F=Format")
     items.append("Q=Quit")
     line = "  ".join(items)
     # Dimming escapes don't take visible space; right-pad to cols by
@@ -331,6 +334,17 @@ def _format_prompt_or_message(state: State, cols: int) -> str:
     if state.prompt_mode == PromptMode.CONFIRM_DELETE:
         slot = state.pending_delete_slot
         return f"Delete partition #{slot}? (y/N)"
+    if state.prompt_mode == PromptMode.ASK_FORMAT:
+        return ("Format: [A]HDI  [P]PDRIVER  [H]DDRIVER  "
+                "(Esc cancel)")
+    if state.prompt_mode == PromptMode.ASK_STRICT_TOS:
+        return "Compatibility with TOS < 1.04? (y/N)"
+    if state.prompt_mode == PromptMode.CONFIRM_DROP_PARTITIONS:
+        n = len(state.pending_drop_slots or [])
+        plural = "" if n == 1 else "s"
+        verb = "violates" if n == 1 else "violate"
+        return (f"{n} partition{plural} {verb} the new format's "
+                "rules. Discard? (y/N)")
     if state.status_message:
         return state.status_message
     return ""

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -338,10 +338,12 @@ def _partition_ident(part, index: int, format_id: str) -> str:
 
     For PPDRIVER / HDDRIVER: every partition is FAT16 in the MBR table.
 
-    A trailing "+" marks chain logicals (those whose ebr_lba > 0 --
-    set by load_image / plan_image when the partition lives inside an
-    EBR chain on hybrid formats or an XGM chain on AHDI). Bare idents
-    mean the partition occupies a primary slot.
+    A trailing "+" marks chain logicals -- partitions whose
+    is_extended is True (the user-side source of truth). ebr_lba is
+    the on-disk projection and is 0 right after load_image's
+    auto-migration flips a primary's is_extended to True; keying on
+    is_extended keeps the display honest in that intermediate state.
+    Bare idents mean the partition occupies a primary slot.
     """
     explicit = getattr(part, "ahdi_ident", None)
     if explicit is not None:
@@ -351,7 +353,7 @@ def _partition_ident(part, index: int, format_id: str) -> str:
         ident = "GEM" if part.size_mb <= atari_hd.AHDI_GEM_MAX_MB else "BGM"
     else:
         ident = "FAT16"
-    if getattr(part, "ebr_lba", 0):
+    if getattr(part, "is_extended", False) or getattr(part, "ebr_lba", 0):
         ident += "+"
     return ident
 

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -12,7 +12,9 @@ afterwards, with D / E / T / W dimmed when the list is empty).
 
 import shutil
 
-from .state import PromptMode, Screen, State
+import atari_hd
+
+from .state import EditField, EditMode, PromptMode, Screen, State
 
 
 # ANSI escape sequences shared across screens.
@@ -54,7 +56,10 @@ def render(state: State) -> str:
     if cols < MIN_COLS or rows < MIN_ROWS:
         return _render_too_small(cols, rows)
     if state.screen == Screen.MAIN:
-        return _render_main(state, cols, rows)
+        frame = _render_main(state, cols, rows)
+        if state.edit_dialog is not None:
+            frame += _render_edit_dialog_overlay(state, cols, rows)
+        return frame
     raise ValueError(f"unknown screen: {state.screen!r}")
 
 
@@ -187,8 +192,21 @@ def _render_partition_list_header(cols: int) -> str:
 
 def _render_partition_row(part, index: int, cols: int,
                           format_id: str, selected: bool) -> str:
-    """One partition row. `part` duck-types atari_hd.Partition --
-    requires .name, .size_mb, .start_lba, .size_sectors."""
+    """One partition row. `part` may be None (a hole left by Delete);
+    set partitions duck-type atari_hd.Partition (.name, .size_mb,
+    .start_lba, .size_sectors)."""
+    if part is None:
+        parts = [
+            " " * LIST_LEFT_MARGIN,
+            f"{index:>{COL_SLOT}}", " " * COL_GAP,
+            "(empty)".ljust(COL_TYPE + COL_GAP + COL_START
+                            + COL_GAP + COL_SIZE + COL_GAP + COL_LABEL),
+        ]
+        body = "".join(parts)
+        body = _pad_to(body, cols)
+        if selected:
+            return INVERSE_ON + body + INVERSE_OFF
+        return body
     ident = _partition_ident(part, index, format_id)
     parts = [
         " " * LIST_LEFT_MARGIN,
@@ -244,20 +262,44 @@ def _render_format_hint(state: State, cols: int) -> str:
     return _pad_to(line, cols)
 
 
+def _has_real_partitions(state: State) -> bool:
+    """True iff state.partitions has at least one non-None entry.
+    Holes (None) left by Delete don't count toward the dim policy."""
+    return any(p is not None for p in state.partitions)
+
+
+def _selected_is_real(state: State) -> bool:
+    """True iff selected_slot points at a real (non-None) partition.
+    D / E require this; T also (since type only applies to AHDI
+    partitions on a real slot)."""
+    if not state.partitions:
+        return False
+    if not 0 <= state.selected_slot < len(state.partitions):
+        return False
+    return state.partitions[state.selected_slot] is not None
+
+
 def _render_status_keys(state: State, cols: int) -> str:
     """Keybinding row. Morphs by state:
        - no image: file actions (N=New L=Load Q=Quit)
-       - image set: partition actions (A/D/E/T/W/Q), with D/E/T/W
-         dimmed when the list is empty.
+       - image set: partition actions (A/D/E/T/W/Q), with D/E/T
+         dimmed when the selected slot is empty (no real partition
+         to act on); W dimmed when there are zero real partitions.
     """
     if state.image_path is None:
         line = "N=New   L=Load   Q=Quit"
         return _pad_to(line, cols)
-    has_partitions = bool(state.partitions)
     items = ["A=Add"]
-    cond = ["D=Delete", "E=Edit", "T=Type", "W=Write"]
-    for k in cond:
-        items.append(k if has_partitions else f"{DIM_ON}{k}{DIM_OFF}")
+    selected_real = _selected_is_real(state)
+    has_real = _has_real_partitions(state)
+    cond = [
+        ("D=Delete", selected_real),
+        ("E=Edit",   selected_real),
+        ("T=Type",   selected_real),
+        ("W=Write",  has_real),
+    ]
+    for label, enabled in cond:
+        items.append(label if enabled else f"{DIM_ON}{label}{DIM_OFF}")
     items.append("Q=Quit")
     line = "  ".join(items)
     # Dimming escapes don't take visible space; right-pad to cols by
@@ -286,6 +328,9 @@ def _format_prompt_or_message(state: State, cols: int) -> str:
         path = state.pending_path or "(unknown)"
         return (f"{path} exists. Press O to overwrite, "
                 "anything else to cancel.")
+    if state.prompt_mode == PromptMode.CONFIRM_DELETE:
+        slot = state.pending_delete_slot
+        return f"Delete partition #{slot}? (y/N)"
     if state.status_message:
         return state.status_message
     return ""
@@ -329,3 +374,173 @@ def _truncate_middle(s: str, max_width: int) -> str:
     head = (max_width - 3) // 2
     tail = max_width - 3 - head
     return s[:head] + "..." + s[-tail:]
+
+
+# -------------------------------------------------------------------
+# Edit dialog overlay (story 004)
+# -------------------------------------------------------------------
+
+DIALOG_WIDTH = 56
+DIALOG_HEIGHT = 13
+
+
+def _render_edit_dialog_overlay(state: State, cols: int, rows: int) -> str:
+    """Centered modal dialog drawn on top of the partition list.
+    Uses absolute cursor positioning so we don't have to redraw the
+    background; the caller composes this after the main frame."""
+    d = state.edit_dialog
+    box_top = max(1, (rows - DIALOG_HEIGHT) // 2 + 1)
+    box_left = max(1, (cols - DIALOG_WIDTH) // 2 + 1)
+
+    title = "Add Partition" if d.mode == EditMode.ADD else f"Edit Partition #{d.slot}"
+    cap_mb = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
+                                       d.type_choice)
+    size_label = f"Size (<= {cap_mb} MB):"
+    size_value = d.size_buffer if d.size_buffer else "_"
+    if d.field == EditField.SIZE:
+        size_value = INVERSE_ON + size_value.ljust(8) + INVERSE_OFF
+    else:
+        size_value = size_value.ljust(8)
+
+    type_locked = (state.format_id == "AHDI" and d.slot == 0)
+    type_visible = state.format_id == "AHDI"
+    if type_visible:
+        if type_locked:
+            type_value = f"GEM (locked)"
+        else:
+            gem = "[GEM]" if d.type_choice == "GEM" else " GEM "
+            bgm = "[BGM]" if d.type_choice == "BGM" else " BGM "
+            type_value = f"{gem}  {bgm}"
+        if d.field == EditField.TYPE and not type_locked:
+            type_value = INVERSE_ON + type_value + INVERSE_OFF
+
+    label_value = d.label_buffer if d.label_buffer else "_"
+    label_value = label_value.ljust(11)
+    if d.field == EditField.LABEL:
+        label_value = INVERSE_ON + label_value + INVERSE_OFF
+
+    error = validate_edit_dialog(state)
+    status_line = "OK" if error is None else error
+
+    # Build the lines that go inside the box. The width budget is
+    # DIALOG_WIDTH - 4 (border + 1 padding each side).
+    inner = DIALOG_WIDTH - 4
+    body_lines = [
+        title.ljust(inner),
+        "",
+        f"  {size_label.ljust(20)} {size_value}",
+    ]
+    if type_visible:
+        body_lines.append(f"  {'Type:'.ljust(20)} {type_value}")
+    body_lines.append(f"  {'Label:'.ljust(20)} {label_value}")
+    body_lines.append("")
+    body_lines.append(_truncate_middle(f"Status: {status_line}", inner))
+    body_lines.append("")
+    body_lines.append(_truncate_middle(
+        "[Tab] field  [t] type  [Enter] save  [Esc] cancel", inner))
+
+    # Pad body to DIALOG_HEIGHT - 2 (top + bottom border rows).
+    while len(body_lines) < DIALOG_HEIGHT - 2:
+        body_lines.append("")
+
+    # Compose the framed box with absolute positioning.
+    out = []
+    # Top border
+    out.append(_cursor_to(box_top, box_left) + "┌" + "─" * (DIALOG_WIDTH - 2) + "┐")
+    # Body
+    for i, body in enumerate(body_lines):
+        # Strip ANSI for length measurement
+        visible = _strip_ansi(body)
+        pad = max(0, (DIALOG_WIDTH - 2) - len(visible))
+        line = "│ " + body + (" " * (pad - 1 if pad >= 1 else 0)) + "│"
+        out.append(_cursor_to(box_top + 1 + i, box_left) + line)
+    # Bottom border
+    out.append(_cursor_to(box_top + DIALOG_HEIGHT - 1, box_left)
+               + "└" + "─" * (DIALOG_WIDTH - 2) + "┘")
+    return "".join(out)
+
+
+def _cursor_to(row: int, col: int) -> str:
+    return f"\x1b[{row};{col}H"
+
+
+def _strip_ansi(s: str) -> str:
+    """Remove ANSI escape sequences for visible-length measurement.
+    Cheap and good-enough for our usage; we only emit \\x1b[<digits>m
+    style sequences from this module."""
+    out = []
+    i = 0
+    while i < len(s):
+        if s[i] == "\x1b" and i + 1 < len(s) and s[i + 1] == "[":
+            # Skip until letter
+            j = i + 2
+            while j < len(s) and not s[j].isalpha():
+                j += 1
+            i = j + 1
+        else:
+            out.append(s[i])
+            i += 1
+    return "".join(out)
+
+
+# -------------------------------------------------------------------
+# Validation (story 004)
+# -------------------------------------------------------------------
+
+LABEL_FORBIDDEN_CHARS = set('*?<>|":+,./;=[]\\\x7f')
+
+
+def is_legal_label_char(ch: str) -> bool:
+    """True if `ch` can be entered into a FAT16 volume label.
+    Mirrors the filter atari_hd._fat16_normalize_label() applies on
+    commit; doing it at input time avoids accumulating illegal chars
+    that would only fail validation later."""
+    if len(ch) != 1:
+        return False
+    if not (32 <= ord(ch) < 127):
+        return False
+    return ch.upper() not in LABEL_FORBIDDEN_CHARS
+
+
+def validate_edit_dialog(state: State):
+    """Return None when the dialog state passes every rule, otherwise
+    a short message naming the *first* failure. The Save action is
+    enabled iff this returns None."""
+    d = state.edit_dialog
+    if d is None:
+        return None
+
+    # Size must be a positive integer.
+    if not d.size_buffer:
+        return "size required"
+    try:
+        size_mb = int(d.size_buffer)
+    except ValueError:
+        return "size must be a number"
+    if size_mb < 1:
+        return "size must be >= 1 MB"
+
+    # Cap depends on the user-chosen type via cap_mb_for_type. For
+    # AHDI slot 0 the dialog locks type to GEM, so cap is the GEM
+    # cap; for hybrid formats type is moot and the cap is the FAT16
+    # ceiling.
+    cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
+                                    d.type_choice)
+    if size_mb > cap:
+        kind = (f"GEM under {'TOS<1.04' if state.strict_tos else 'TOS 1.04+'}"
+                if state.format_id == "AHDI" and d.type_choice == "GEM"
+                else "BGM" if state.format_id == "AHDI"
+                else "FAT16")
+        return f"size exceeds {cap} MB cap for {kind}"
+
+    # Label validation -- empty is OK (we'll default to a generated
+    # name on commit), otherwise must be uppercase ASCII per the
+    # FAT16 short-name rules. is_legal_label_char already filters
+    # at input time so this check should normally pass.
+    if d.label_buffer and len(d.label_buffer) > 11:
+        return "label too long (max 11 chars)"
+    for ch in d.label_buffer:
+        if not is_legal_label_char(ch):
+            return f"label has illegal character: {ch!r}"
+
+    return None

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -4,9 +4,10 @@ Each call returns a complete fresh frame; we don't diff. At our screen
 sizes (80x24+) writing the whole screen on every dirty flag is not
 measurable and the implementation stays simple.
 
-Story 002 lands the three-region main screen (header / body /
-status bar) plus the "terminal too small" fallback. Stories 003+
-extend the body and the keybinding list.
+Story 003 fills the body with a partition list (column header +
+selectable rows + format hint), and morphs the keybinding row by
+state (file actions before an image is loaded; partition actions
+afterwards, with D / E / T / W dimmed when the list is empty).
 """
 
 import shutil
@@ -17,6 +18,10 @@ from .state import PromptMode, Screen, State
 # ANSI escape sequences shared across screens.
 CLEAR_SCREEN = "\x1b[2J"
 CURSOR_HOME = "\x1b[H"
+INVERSE_ON = "\x1b[7m"
+INVERSE_OFF = "\x1b[27m"
+DIM_ON = "\x1b[2m"
+DIM_OFF = "\x1b[22m"
 
 
 # Hard floor on terminal size. Below either dimension the layout
@@ -30,6 +35,16 @@ MIN_ROWS = 24
 # all three target terminals (Terminal.app / iTerm2 / Windows
 # Terminal / modern Linux terminals).
 HLINE = "─"   # ─
+
+
+# Partition-list column widths, in order.
+COL_SLOT = 4
+COL_TYPE = 5
+COL_START = 12
+COL_SIZE = 10
+COL_LABEL = 13
+COL_GAP = 2
+LIST_LEFT_MARGIN = 2
 
 
 def render(state: State) -> str:
@@ -51,25 +66,22 @@ def _render_too_small(cols: int, rows: int) -> str:
 
 
 def _render_main(state: State, cols: int, rows: int) -> str:
-    # Layout (24-row baseline; expands at the body for taller terminals):
+    # Layout (rows-row baseline; expands at the body for taller terminals):
     #   row 1:        header line
     #   row 2:        separator
-    #   rows 3..N-3:  body (placeholder for now; partition list in 003)
+    #   rows 3..N-3:  body (partition list area)
     #   row N-2:      separator
     #   row N-1:      key bindings
     #   row N:        prompt or transient status message
-    body_rows = rows - 4  # header + 2 separators + status keys row
-    # Status occupies 2 rows (keys + prompt/message); we already
-    # reserved one of those by counting "rows - 4" above. Reserve one
-    # more by trimming body_rows.
-    body_rows -= 1
+    body_rows = rows - 4    # header + 2 separators + status keys row
+    body_rows -= 1          # plus the final prompt/status row
 
     parts = [CLEAR_SCREEN, CURSOR_HOME,
              _render_header(state, cols), "\r\n",
              _hline(cols), "\r\n",
              _render_body(state, cols, body_rows),
              _hline(cols), "\r\n",
-             _render_status_keys(cols), "\r\n",
+             _render_status_keys(state, cols), "\r\n",
              _render_status_message(state, cols)]
     return "".join(parts)
 
@@ -84,56 +96,181 @@ def _render_header(state: State, cols: int) -> str:
         right = "(no image)"
     else:
         right = f"image: {state.image_path}"
-    # Left + right with a 2-space minimum gap; truncate the right
-    # half (which is the path) when there isn't room.
     gap = 2
     available_for_right = cols - len(left) - gap
     if available_for_right < len(right):
         right = _truncate_middle(right, max(available_for_right, 5))
     pad = cols - len(left) - len(right)
     if pad < 0:
-        # left too long for cols (shouldn't happen at 80+ cols, but be
-        # defensive); just hard-truncate.
         return (left + " " + right)[:cols]
     return left + (" " * pad) + right
 
 
 def _render_body(state: State, cols: int, height: int) -> str:
-    """Render the partition-list area. Story 002 leaves it as a
-    centered hint; story 003 fills it with the real list."""
+    """Render the partition-list area with a format hint at the
+    bottom. The body has three shapes:
+       - no image: "press N or L" hint, no list, no format row
+       - image set, no partitions: "press A to add" centered, format row
+       - image set, partitions: column header + rows + format row
+    """
     if state.image_path is None:
-        msg = "No image selected. Press N to create one or L to load an existing image."
-    else:
-        msg = "(partition list -- story 003 fills this in)"
-    msg = _truncate_middle(msg, cols - 2)
+        return _render_body_no_image(cols, height)
+    if not state.partitions:
+        return _render_body_empty_partitions(state, cols, height)
+    return _render_body_partitions(state, cols, height)
 
-    lines = []
-    # Show the message centered on the middle row of the body. All
-    # other body rows are empty (full-width to overwrite anything from
-    # a previous larger frame).
-    middle = height // 2
+
+def _render_body_no_image(cols: int, height: int) -> str:
+    msg = "No image selected. Press N to create one or L to load an existing image."
+    return _centered_in_body(msg, cols, height)
+
+
+def _render_body_empty_partitions(state: State, cols: int, height: int) -> str:
+    """Image set but partition list empty: centered hint, format row at
+    the bottom."""
+    msg = "No partitions defined -- press A to add"
+    msg = _truncate_middle(msg, cols - 2)
     blank = " " * cols
-    for i in range(height):
+    fmt_line = _render_format_hint(state, cols)
+    lines = []
+    middle = (height - 1) // 2
+    for i in range(height - 1):
         if i == middle:
             pad_left = max(0, (cols - len(msg)) // 2)
             line = (" " * pad_left) + msg
-            line += " " * max(0, cols - len(line))
-            lines.append(line[:cols])
+            lines.append(_pad_to(line, cols))
         else:
             lines.append(blank)
+    lines.append(fmt_line)
     return "\r\n".join(lines) + "\r\n"
 
 
-def _render_status_keys(cols: int) -> str:
-    keys = "N=New   L=Load   Q=Quit"
-    if len(keys) > cols:
-        return keys[:cols]
-    return keys + (" " * (cols - len(keys)))
+def _render_body_partitions(state: State, cols: int, height: int) -> str:
+    """Image set and partitions present: column header + rows +
+    format row. Selection is highlighted with reverse video.
+    """
+    blank = " " * cols
+    list_rows_visible = height - 2  # header + format row
+    # Adjust scroll_top to keep selected_slot visible.
+    scroll = state.scroll_top
+    if state.selected_slot < scroll:
+        scroll = state.selected_slot
+    elif state.selected_slot >= scroll + list_rows_visible:
+        scroll = state.selected_slot - list_rows_visible + 1
+
+    lines = [_render_partition_list_header(cols)]
+    for i in range(list_rows_visible):
+        idx = scroll + i
+        if idx < len(state.partitions):
+            row = _render_partition_row(state.partitions[idx], idx, cols,
+                                        format_id=state.format_id,
+                                        selected=(idx == state.selected_slot))
+            lines.append(row)
+        else:
+            lines.append(blank)
+    lines.append(_render_format_hint(state, cols))
+    return "\r\n".join(lines) + "\r\n"
+
+
+def _render_partition_list_header(cols: int) -> str:
+    """Column header row, padded to `cols`."""
+    parts = [
+        " " * LIST_LEFT_MARGIN,
+        "Slot".rjust(COL_SLOT), " " * COL_GAP,
+        "Type".ljust(COL_TYPE), " " * COL_GAP,
+        "Start (LBA)".rjust(COL_START), " " * COL_GAP,
+        "Size".rjust(COL_SIZE), " " * COL_GAP,
+        "Label".ljust(COL_LABEL),
+    ]
+    return _pad_to("".join(parts), cols)
+
+
+def _render_partition_row(part, index: int, cols: int,
+                          format_id: str, selected: bool) -> str:
+    """One partition row. `part` duck-types atari_hd.Partition --
+    requires .name, .size_mb, .start_lba, .size_sectors."""
+    ident = _partition_ident(part, index, format_id)
+    parts = [
+        " " * LIST_LEFT_MARGIN,
+        f"{index:>{COL_SLOT}}", " " * COL_GAP,
+        ident.ljust(COL_TYPE), " " * COL_GAP,
+        f"{part.start_lba:>{COL_START},}", " " * COL_GAP,
+        _format_size(part.size_mb).rjust(COL_SIZE), " " * COL_GAP,
+        _truncate_middle(part.name, COL_LABEL).ljust(COL_LABEL),
+    ]
+    body = "".join(parts)
+    body = _pad_to(body, cols)
+    if selected:
+        return INVERSE_ON + body + INVERSE_OFF
+    return body
+
+
+def _partition_ident(part, index: int, format_id: str) -> str:
+    """Best-effort short ident for the type column. Honors an explicit
+    `ahdi_ident` attribute when story 004 starts setting one; otherwise
+    derives a v1 value from the format and slot index.
+
+    For AHDI: slot 0 is forced GEM (boot rule); later slots flip to BGM
+    above the 32 MB threshold.
+    For PPDRIVER / HDDRIVER: every partition is FAT16 in the MBR table
+    (the EBR-chain "extended" type is the chain header, not a partition
+    the user listed).
+    """
+    explicit = getattr(part, "ahdi_ident", None)
+    if explicit is not None:
+        return explicit if isinstance(explicit, str) else explicit.decode(
+            "ascii", errors="replace")
+    if format_id == "AHDI":
+        if index == 0:
+            return "GEM"
+        return "GEM" if part.size_mb <= 32 else "BGM"
+    return "FAT16"
+
+
+def _format_size(mb: int) -> str:
+    """MB up to 999.9; GB beyond. One decimal."""
+    if mb < 1000:
+        return f"{mb:.1f} MB"
+    return f"{mb / 1024:.1f} GB"
+
+
+def _render_format_hint(state: State, cols: int) -> str:
+    fmt = state.format_id
+    if state.format_id == "AHDI":
+        tos = f"  TOS<1.04: {'on' if state.strict_tos else 'off'}"
+    else:
+        tos = ""
+    line = f"  Format: {fmt}{tos}"
+    return _pad_to(line, cols)
+
+
+def _render_status_keys(state: State, cols: int) -> str:
+    """Keybinding row. Morphs by state:
+       - no image: file actions (N=New L=Load Q=Quit)
+       - image set: partition actions (A/D/E/T/W/Q), with D/E/T/W
+         dimmed when the list is empty.
+    """
+    if state.image_path is None:
+        line = "N=New   L=Load   Q=Quit"
+        return _pad_to(line, cols)
+    has_partitions = bool(state.partitions)
+    items = ["A=Add"]
+    cond = ["D=Delete", "E=Edit", "T=Type", "W=Write"]
+    for k in cond:
+        items.append(k if has_partitions else f"{DIM_ON}{k}{DIM_OFF}")
+    items.append("Q=Quit")
+    line = "  ".join(items)
+    # Dimming escapes don't take visible space; right-pad to cols by
+    # measuring the *visible* width.
+    visible_len = sum(len(k.replace(DIM_ON, "").replace(DIM_OFF, ""))
+                      for k in items) + 2 * (len(items) - 1)
+    pad = max(0, cols - visible_len)
+    return line + (" " * pad)
 
 
 def _render_status_message(state: State, cols: int) -> str:
-    """Bottom row: either a prompt (when prompt_mode is active) or a
-    transient status message, or blank."""
+    """Bottom row: prompt (when prompt_mode is active), transient
+    status message, or blank."""
     line = _format_prompt_or_message(state, cols)
     if len(line) > cols:
         line = line[:cols]
@@ -154,8 +291,36 @@ def _format_prompt_or_message(state: State, cols: int) -> str:
     return ""
 
 
+# -------------------------------------------------------------------
+# Layout helpers
+# -------------------------------------------------------------------
+
+def _centered_in_body(msg: str, cols: int, height: int) -> str:
+    msg = _truncate_middle(msg, cols - 2)
+    blank = " " * cols
+    middle = height // 2
+    lines = []
+    for i in range(height):
+        if i == middle:
+            pad_left = max(0, (cols - len(msg)) // 2)
+            lines.append(_pad_to(" " * pad_left + msg, cols))
+        else:
+            lines.append(blank)
+    return "\r\n".join(lines) + "\r\n"
+
+
+def _pad_to(s: str, cols: int) -> str:
+    """Right-pad `s` with spaces to exactly `cols` characters
+    (visible). Caller is responsible for not embedding wider escapes
+    in `s` -- this is a plain len()-based padder; functions that emit
+    ANSI styling do their own padding."""
+    if len(s) >= cols:
+        return s[:cols]
+    return s + " " * (cols - len(s))
+
+
 def _truncate_middle(s: str, max_width: int) -> str:
-    """Shorten `s` to fit within `max_width` using a "...".  separator
+    """Shorten `s` to fit within `max_width` using a "..." separator
     in the middle. For very short widths just hard-truncate."""
     if len(s) <= max_width:
         return s

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -1,0 +1,39 @@
+"""Pure rendering: state -> frame string with embedded ANSI escapes.
+
+Each public function in this module takes a State and returns a string
+that, when written to stdout, produces a complete fresh frame. No
+incremental diffing; we redraw the whole screen on every dirty flag.
+At our screen sizes (80x24+) this is not measurable.
+
+Story 001 only renders the PLACEHOLDER screen. Stories 002-008 add
+the real screens; each gets its own _render_<name> private function
+and is dispatched by render() based on state.screen.
+"""
+
+from .state import Screen, State
+
+
+# ANSI escape sequences shared across screens.
+CLEAR_SCREEN = "\x1b[2J"
+CURSOR_HOME = "\x1b[H"
+
+
+def render(state: State) -> str:
+    """Return a complete frame string for the current screen."""
+    if state.screen == Screen.PLACEHOLDER:
+        return _render_placeholder(state)
+    raise ValueError(f"unknown screen: {state.screen!r}")
+
+
+def _render_placeholder(state: State) -> str:
+    return (
+        CLEAR_SCREEN
+        + CURSOR_HOME
+        + "SidecarTridge atari-hd image creator (TUI)\r\n"
+        + "\r\n"
+        + "  Skeleton -- epic-003 / story 001\r\n"
+        + "\r\n"
+        + "  Real screens land in stories 002-008.\r\n"
+        + "\r\n"
+        + "  Press q, Esc, or Ctrl-C to quit.\r\n"
+    )

--- a/scripts/atari-hd/tui/render.py
+++ b/scripts/atari-hd/tui/render.py
@@ -150,6 +150,35 @@ def _render_body_empty_partitions(state: State, cols: int, height: int) -> str:
     return "\r\n".join(lines) + "\r\n"
 
 
+def _display_start_lbas(state: State) -> list:
+    """Return [start_lba_i] for each slot in `state.partitions` for the
+    "Start (LBA)" column.
+
+    `Partition.start_lba` is only populated by `plan_image()` at write
+    time, so partitions added in the dialog show 0 until the user hits
+    W. We mirror plan_image's sequential placement here so the list
+    reflects something useful while the user is still composing.
+
+    Approximate, not authoritative -- we don't account for the EBR/XGM
+    chain overhead that plan_image inserts (a sector or two before each
+    logical when N exceeds the format's primary-slot count). Slots that
+    are None (a hole left by Delete) get 0 and don't advance the
+    cursor, matching plan_image which skips them entirely.
+    """
+    if not state.partitions:
+        return []
+    next_lba = atari_hd.first_partition_start_lba(state.format_id)
+    out = []
+    for part in state.partitions:
+        if part is None:
+            out.append(0)
+            continue
+        out.append(next_lba)
+        size_sectors = (part.size_mb * 1024 * 1024) // 512
+        next_lba += size_sectors
+    return out
+
+
 def _render_body_partitions(state: State, cols: int, height: int) -> str:
     """Image set and partitions present: column header + rows +
     format row. Selection is highlighted with reverse video.
@@ -163,13 +192,16 @@ def _render_body_partitions(state: State, cols: int, height: int) -> str:
     elif state.selected_slot >= scroll + list_rows_visible:
         scroll = state.selected_slot - list_rows_visible + 1
 
+    display_lbas = _display_start_lbas(state)
     lines = [_render_partition_list_header(cols)]
     for i in range(list_rows_visible):
         idx = scroll + i
         if idx < len(state.partitions):
+            lba = display_lbas[idx] if idx < len(display_lbas) else 0
             row = _render_partition_row(state.partitions[idx], idx, cols,
                                         format_id=state.format_id,
-                                        selected=(idx == state.selected_slot))
+                                        selected=(idx == state.selected_slot),
+                                        start_lba_override=lba)
             lines.append(row)
         else:
             lines.append(blank)
@@ -191,10 +223,16 @@ def _render_partition_list_header(cols: int) -> str:
 
 
 def _render_partition_row(part, index: int, cols: int,
-                          format_id: str, selected: bool) -> str:
+                          format_id: str, selected: bool,
+                          start_lba_override=None) -> str:
     """One partition row. `part` may be None (a hole left by Delete);
     set partitions duck-type atari_hd.Partition (.name, .size_mb,
-    .start_lba, .size_sectors)."""
+    .start_lba, .size_sectors).
+
+    `start_lba_override` lets the caller display a sequentially-derived
+    LBA (computed by `_display_start_lbas`) instead of `part.start_lba`,
+    which is only populated by `plan_image()` at write time.
+    """
     if part is None:
         parts = [
             " " * LIST_LEFT_MARGIN,
@@ -208,11 +246,12 @@ def _render_partition_row(part, index: int, cols: int,
             return INVERSE_ON + body + INVERSE_OFF
         return body
     ident = _partition_ident(part, index, format_id)
+    lba = part.start_lba if start_lba_override is None else start_lba_override
     parts = [
         " " * LIST_LEFT_MARGIN,
         f"{index:>{COL_SLOT}}", " " * COL_GAP,
         ident.ljust(COL_TYPE), " " * COL_GAP,
-        f"{part.start_lba:>{COL_START},}", " " * COL_GAP,
+        f"{lba:>{COL_START},}", " " * COL_GAP,
         _format_size(part.size_mb).rjust(COL_SIZE), " " * COL_GAP,
         _truncate_middle(part.name, COL_LABEL).ljust(COL_LABEL),
     ]
@@ -292,7 +331,10 @@ def _render_status_keys(state: State, cols: int) -> str:
     if state.image_path is None:
         line = "N=New   L=Load   Q=Quit"
         return _pad_to(line, cols)
-    items = ["A=Add"]
+    # File actions stay visible even after an image is loaded so the
+    # user can create a fresh plan or load a different file mid-session
+    # without exiting first.
+    items = ["N=New", "L=Load", "A=Add"]
     selected_real = _selected_is_real(state)
     has_real = _has_real_partitions(state)
     cond = [
@@ -350,6 +392,8 @@ def _format_prompt_or_message(state: State, cols: int) -> str:
         return f"Overwrite {state.image_path}? (y/N)"
     if state.prompt_mode == PromptMode.CONFIRM_DISCARD_UNSAVED:
         return "Discard unsaved changes? (y/N)"
+    if state.prompt_mode == PromptMode.CONFIRM_DISCARD_BEFORE_LOAD:
+        return "Discard unsaved changes and load? (y/N)"
     if state.status_message:
         return state.status_message
     return ""
@@ -414,7 +458,14 @@ def _render_edit_dialog_overlay(state: State, cols: int, rows: int) -> str:
     title = "Add Partition" if d.mode == EditMode.ADD else f"Edit Partition #{d.slot}"
     cap_mb = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
                                        d.type_choice)
-    size_label = f"Size (<= {cap_mb} MB):"
+    min_mb = atari_hd.format_min_partition_mb(state.format_id)
+    if min_mb > 1:
+        # Hybrid formats have a hard 32 MB floor; surface the range
+        # so users don't type a 16 MB hybrid partition and hit the
+        # build-time min-size rejection later.
+        size_label = f"Size ({min_mb}-{cap_mb} MB):"
+    else:
+        size_label = f"Size (<= {cap_mb} MB):"
     size_value = d.size_buffer if d.size_buffer else "_"
     if d.field == EditField.SIZE:
         size_value = INVERSE_ON + size_value.ljust(8) + INVERSE_OFF
@@ -541,15 +592,19 @@ def validate_edit_dialog(state: State):
 
     # Cap depends on the user-chosen type via cap_mb_for_type. For
     # AHDI slot 0 the dialog locks type to GEM, so cap is the GEM
-    # cap; for hybrid formats type is moot and the cap is the FAT16
-    # ceiling.
+    # cap; for hybrid formats type is moot and the cap is the
+    # hybrid TOS-NSECTS ceiling.
     cap = atari_hd.cap_mb_for_type(state.format_id, state.strict_tos,
                                     d.type_choice)
+    min_mb = atari_hd.format_min_partition_mb(state.format_id)
+    if size_mb < min_mb:
+        return (f"size below {min_mb} MB minimum for "
+                f"{state.format_id} hybrid layout")
     if size_mb > cap:
         kind = (f"GEM under {'TOS<1.04' if state.strict_tos else 'TOS 1.04+'}"
                 if state.format_id == "AHDI" and d.type_choice == "GEM"
                 else "BGM" if state.format_id == "AHDI"
-                else "FAT16")
+                else f"{state.format_id} hybrid")
         return f"size exceeds {cap} MB cap for {kind}"
 
     # Label validation -- empty is OK (we'll default to a generated

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -34,6 +34,34 @@ class PromptMode(Enum):
     ASK_NEW_PATH = "ask_new_path"
     ASK_LOAD_PATH = "ask_load_path"
     CONFIRM_OVERWRITE = "confirm_overwrite"
+    CONFIRM_DELETE = "confirm_delete"
+
+
+class EditField(Enum):
+    """Focused field inside the add/edit dialog."""
+    SIZE = "size"
+    TYPE = "type"
+    LABEL = "label"
+
+
+class EditMode(Enum):
+    ADD = "add"
+    EDIT = "edit"
+
+
+@dataclass
+class EditDialogState:
+    """In-flight state of the modal partition-edit dialog. Lives on
+    State.edit_dialog while the dialog is open; cleared on cancel /
+    commit."""
+    mode: EditMode
+    # For ADD: the slot index the partition will land in (first hole
+    # or len(partitions)). For EDIT: the slot being edited.
+    slot: int
+    field: EditField = EditField.SIZE
+    size_buffer: str = ""           # digits only
+    type_choice: str = "GEM"        # "GEM" / "BGM"; ignored on hybrid formats
+    label_buffer: str = ""          # accumulated uppercase ASCII, <= 11 chars
 
 
 @dataclass
@@ -64,11 +92,18 @@ class State:
     format_id: str = "AHDI"
     # AHDI-only: TOS<1.04 strict caps. Ignored on the hybrid formats.
     strict_tos: bool = False
-    # In-memory partition list. Items are atari_hd.Partition instances,
-    # but render.py only depends on duck-typed attribute access
-    # (.name / .size_mb / .start_lba / .size_sectors), so this module
-    # doesn't import atari_hd.
+    # In-memory partition list. Items are atari_hd.Partition instances
+    # *or* None (sparse holes left by Delete; the next Add fills the
+    # first hole). render.py only depends on duck-typed attribute access
+    # (.name / .size_mb / .start_lba / .size_sectors / .ahdi_ident on
+    # set partitions; None entries are rendered as "(empty)"), so this
+    # module doesn't import atari_hd.
     partitions: List = field(default_factory=list)
+    # Open edit dialog (None when no dialog is up).
+    edit_dialog: Optional[EditDialogState] = None
+    # Slot index pending deletion -- carried through CONFIRM_DELETE so
+    # the confirm dialog knows which partition the y/n applies to.
+    pending_delete_slot: Optional[int] = None
     # Index of the highlighted row in the partition list.
     selected_slot: int = 0
     # First visible row when the list is taller than the body. With

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -4,25 +4,36 @@ A single dataclass holds everything the event loop and renderer need.
 No module globals; no thread-local storage. The event loop owns the
 only instance.
 
-Story 001 keeps the state minimal -- just enough to drive the
-placeholder screen and the exit handling. Stories 002+ add fields as
-they introduce new screens and operations.
+Story 002 introduces the main screen (image-file management) and the
+inline-prompt sub-mode for asking the user for a filename or an
+overwrite confirmation. Stories 003+ extend State with partitions,
+format/strict_tos, and unsaved-changes tracking.
 """
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
 
 class Screen(Enum):
     """Screen identifiers. Each render path maps one Screen to a frame
     string in render.py."""
-    PLACEHOLDER = "placeholder"
-    # Story 002: MAIN
-    # Story 003: PARTITION_LIST
+    MAIN = "main"
+    # Story 003: PARTITION_LIST  (likely folded into MAIN's body)
     # Story 004: EDIT_DIALOG
     # Story 005: FORMAT_SELECTOR
     # Story 006: WRITE_CONFIRM
     # Story 008: HELP
+
+
+class PromptMode(Enum):
+    """Inline-prompt sub-mode. When OFF the status bar shows the key
+    bindings; otherwise it shows a question (with optional buffered
+    text input) and routes keys through the prompt handler."""
+    OFF = "off"
+    ASK_NEW_PATH = "ask_new_path"
+    ASK_LOAD_PATH = "ask_load_path"
+    CONFIRM_OVERWRITE = "confirm_overwrite"
 
 
 @dataclass
@@ -33,6 +44,17 @@ class State:
     event loop clears it after writing the frame. `exit_requested` is
     the loop's termination flag.
     """
-    screen: Screen = Screen.PLACEHOLDER
+    screen: Screen = Screen.MAIN
+    image_path: Optional[str] = None
+    prompt_mode: PromptMode = PromptMode.OFF
+    prompt_buffer: str = ""
+    # Path the user just typed but that already exists -- carried into
+    # CONFIRM_OVERWRITE so the confirm dialog can show what it'd
+    # overwrite and apply it on accept.
+    pending_path: Optional[str] = None
+    # Transient one-line message shown on the bottom row of the status
+    # bar (e.g. "file not found", "load not yet implemented"). Cleared
+    # on the next state-mutating key.
+    status_message: Optional[str] = None
     dirty: bool = True
     exit_requested: bool = False

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -39,6 +39,9 @@ class PromptMode(Enum):
     ASK_FORMAT = "ask_format"
     ASK_STRICT_TOS = "ask_strict_tos"
     CONFIRM_DROP_PARTITIONS = "confirm_drop_partitions"
+    # Commit / write flow (story 006)
+    CONFIRM_OVERWRITE_WRITE = "confirm_overwrite_write"
+    CONFIRM_DISCARD_UNSAVED = "confirm_discard_unsaved"
 
 
 class EditField(Enum):
@@ -119,6 +122,11 @@ class State:
     pending_format: Optional[str] = None
     pending_strict_tos: Optional[bool] = None
     pending_drop_slots: Optional[List[int]] = None
+
+    # Story 006: True when the in-memory plan has changed since the
+    # last successful write. Set by every mutating handler; cleared
+    # on successful write and on image_path change (load / new).
+    unsaved_changes: bool = False
     # Index of the highlighted row in the partition list.
     selected_slot: int = 0
     # First visible row when the list is taller than the body. With

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -1,0 +1,38 @@
+"""TUI state container.
+
+A single dataclass holds everything the event loop and renderer need.
+No module globals; no thread-local storage. The event loop owns the
+only instance.
+
+Story 001 keeps the state minimal -- just enough to drive the
+placeholder screen and the exit handling. Stories 002+ add fields as
+they introduce new screens and operations.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Screen(Enum):
+    """Screen identifiers. Each render path maps one Screen to a frame
+    string in render.py."""
+    PLACEHOLDER = "placeholder"
+    # Story 002: MAIN
+    # Story 003: PARTITION_LIST
+    # Story 004: EDIT_DIALOG
+    # Story 005: FORMAT_SELECTOR
+    # Story 006: WRITE_CONFIRM
+    # Story 008: HELP
+
+
+@dataclass
+class State:
+    """Top-level TUI state.
+
+    `dirty` is True when the next loop iteration should redraw; the
+    event loop clears it after writing the frame. `exit_requested` is
+    the loop's termination flag.
+    """
+    screen: Screen = Screen.PLACEHOLDER
+    dirty: bool = True
+    exit_requested: bool = False

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -48,6 +48,7 @@ class PromptMode(Enum):
 
 class EditField(Enum):
     """Focused field inside the add/edit dialog."""
+    KIND = "kind"               # primary vs extended (hybrid formats)
     SIZE = "size"
     TYPE = "type"
     LABEL = "label"
@@ -70,6 +71,14 @@ class EditDialogState:
     field: EditField = EditField.SIZE
     size_buffer: str = ""           # digits only
     type_choice: str = "GEM"        # "GEM" / "BGM"; ignored on hybrid formats
+    # For hybrid formats: which kind of partition the user is choosing.
+    # "primary" or "extended". Locked to "primary" for slot 0; locked to
+    # "extended" for HDDRIVER slot >= 1; free choice for PPDRIVER slot
+    # >= 1. Drives the per-partition cap (255 vs 511 MB) and where
+    # plan_image will place the partition (MBR slot vs extended chain).
+    # Ignored on AHDI -- AHDI primary/extended split is still derived
+    # from N until the AHDI side gets the same per-partition toggle.
+    kind_choice: str = "primary"
     label_buffer: str = ""          # accumulated uppercase ASCII, <= 11 chars
 
 

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -10,9 +10,9 @@ overwrite confirmation. Stories 003+ extend State with partitions,
 format/strict_tos, and unsaved-changes tracking.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 
 
 class Screen(Enum):
@@ -56,5 +56,26 @@ class State:
     # bar (e.g. "file not found", "load not yet implemented"). Cleared
     # on the next state-mutating key.
     status_message: Optional[str] = None
+
+    # Partition plan -----------------------------------------------------
+    # Driver format. Values match atari_hd.FORMAT_AHDI / FORMAT_PPDRIVER /
+    # FORMAT_HDDRIVER (plain strings). Stored as a string so this module
+    # does not need to import atari_hd.
+    format_id: str = "AHDI"
+    # AHDI-only: TOS<1.04 strict caps. Ignored on the hybrid formats.
+    strict_tos: bool = False
+    # In-memory partition list. Items are atari_hd.Partition instances,
+    # but render.py only depends on duck-typed attribute access
+    # (.name / .size_mb / .start_lba / .size_sectors), so this module
+    # doesn't import atari_hd.
+    partitions: List = field(default_factory=list)
+    # Index of the highlighted row in the partition list.
+    selected_slot: int = 0
+    # First visible row when the list is taller than the body. With
+    # MAX_PARTITIONS=14 and ~17 visible rows at 80x24 the value stays
+    # at 0 in practice; the code path exists for taller plans.
+    scroll_top: int = 0
+    # -------------------------------------------------------------------
+
     dirty: bool = True
     exit_requested: bool = False

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -129,6 +129,11 @@ class State:
     # last successful write. Set by every mutating handler; cleared
     # on successful write and on image_path change (load / new).
     unsaved_changes: bool = False
+    # Story 008: help overlay visibility. Toggled by `?` from any
+    # screen; Esc / `?` while open closes it. Layers on top of every
+    # other UI element (main / dialog / prompt) without disturbing
+    # them, so closing returns the user to whatever was underneath.
+    show_help: bool = False
     # Index of the highlighted row in the partition list.
     selected_slot: int = 0
     # First visible row when the list is taller than the body. With

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -35,6 +35,10 @@ class PromptMode(Enum):
     ASK_LOAD_PATH = "ask_load_path"
     CONFIRM_OVERWRITE = "confirm_overwrite"
     CONFIRM_DELETE = "confirm_delete"
+    # Format selector (story 005)
+    ASK_FORMAT = "ask_format"
+    ASK_STRICT_TOS = "ask_strict_tos"
+    CONFIRM_DROP_PARTITIONS = "confirm_drop_partitions"
 
 
 class EditField(Enum):
@@ -104,6 +108,17 @@ class State:
     # Slot index pending deletion -- carried through CONFIRM_DELETE so
     # the confirm dialog knows which partition the y/n applies to.
     pending_delete_slot: Optional[int] = None
+
+    # Format-selector pending state (story 005). pending_format is set
+    # when the user picks a format but the change hasn't been applied
+    # yet (might still need ASK_STRICT_TOS or CONFIRM_DROP_PARTITIONS
+    # before commit). pending_strict_tos likewise. pending_drop_slots
+    # is the list of partition indices that would violate the pending
+    # format's caps; the user is asked to discard them via
+    # CONFIRM_DROP_PARTITIONS.
+    pending_format: Optional[str] = None
+    pending_strict_tos: Optional[bool] = None
+    pending_drop_slots: Optional[List[int]] = None
     # Index of the highlighted row in the partition list.
     selected_slot: int = 0
     # First visible row when the list is taller than the body. With

--- a/scripts/atari-hd/tui/state.py
+++ b/scripts/atari-hd/tui/state.py
@@ -42,6 +42,8 @@ class PromptMode(Enum):
     # Commit / write flow (story 006)
     CONFIRM_OVERWRITE_WRITE = "confirm_overwrite_write"
     CONFIRM_DISCARD_UNSAVED = "confirm_discard_unsaved"
+    # Load existing image (story 007)
+    CONFIRM_DISCARD_BEFORE_LOAD = "confirm_discard_before_load"
 
 
 class EditField(Enum):

--- a/scripts/atari-hd/tui/terminal.py
+++ b/scripts/atari-hd/tui/terminal.py
@@ -27,15 +27,30 @@ def _emit(seq: str) -> None:
 
 
 if os.name == "posix":
+    import signal
     import termios
     import tty
+
+    from . import input as _tui_input
+
+    def _on_sigwinch(_signum, _frame):
+        # Set a module-level flag that read_key() in input.py drains
+        # after an interrupted os.read. The event loop then redraws
+        # with the new terminal size on the next iteration.
+        _tui_input.resize_pending = True
 
     @contextmanager
     def terminal_session():
         """Raw mode + alt screen + hidden cursor for the duration of
-        the block. Restores everything on any exit path."""
+        the block. Restores everything on any exit path. Installs a
+        SIGWINCH handler so terminal resizes wake up read_key() with
+        Key.RESIZE; uninstalls on exit."""
         fd = sys.stdin.fileno()
         old_attrs = termios.tcgetattr(fd)
+        old_winch = signal.signal(signal.SIGWINCH, _on_sigwinch)
+        # siginterrupt(True) makes os.read return EINTR on signal
+        # delivery instead of being auto-restarted.
+        signal.siginterrupt(signal.SIGWINCH, True)
         try:
             tty.setraw(fd)
             _emit(ENTER_ALT_SCREEN + HIDE_CURSOR)
@@ -43,6 +58,7 @@ if os.name == "posix":
         finally:
             _emit(SHOW_CURSOR + EXIT_ALT_SCREEN)
             termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+            signal.signal(signal.SIGWINCH, old_winch)
 
 elif os.name == "nt":
     import ctypes

--- a/scripts/atari-hd/tui/terminal.py
+++ b/scripts/atari-hd/tui/terminal.py
@@ -1,0 +1,95 @@
+"""Cross-platform terminal session manager.
+
+Enters raw mode, switches to the alternate screen buffer, and hides
+the cursor on `__enter__`; restores everything on `__exit__` --
+including on KeyboardInterrupt and unhandled exceptions, which is
+the only thing standing between a crash and a broken shell.
+
+Unix path uses termios + tty.
+Windows path uses kernel32.SetConsoleMode via ctypes.
+"""
+
+import os
+import sys
+from contextlib import contextmanager
+
+
+# ANSI escape sequences for terminal-state setup / teardown.
+ENTER_ALT_SCREEN = "\x1b[?1049h"
+EXIT_ALT_SCREEN = "\x1b[?1049l"
+HIDE_CURSOR = "\x1b[?25l"
+SHOW_CURSOR = "\x1b[?25h"
+
+
+def _emit(seq: str) -> None:
+    sys.stdout.write(seq)
+    sys.stdout.flush()
+
+
+if os.name == "posix":
+    import termios
+    import tty
+
+    @contextmanager
+    def terminal_session():
+        """Raw mode + alt screen + hidden cursor for the duration of
+        the block. Restores everything on any exit path."""
+        fd = sys.stdin.fileno()
+        old_attrs = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            _emit(ENTER_ALT_SCREEN + HIDE_CURSOR)
+            yield
+        finally:
+            _emit(SHOW_CURSOR + EXIT_ALT_SCREEN)
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+
+elif os.name == "nt":
+    import ctypes
+    from ctypes import wintypes
+
+    # Console mode bits we care about.
+    _ENABLE_PROCESSED_INPUT = 0x0001
+    _ENABLE_LINE_INPUT = 0x0002
+    _ENABLE_ECHO_INPUT = 0x0004
+    _ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
+    _ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
+    _STD_INPUT_HANDLE = -10
+    _STD_OUTPUT_HANDLE = -11
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _kernel32.GetStdHandle.restype = wintypes.HANDLE
+    _kernel32.GetConsoleMode.argtypes = (wintypes.HANDLE,
+                                         ctypes.POINTER(wintypes.DWORD))
+    _kernel32.SetConsoleMode.argtypes = (wintypes.HANDLE,
+                                         wintypes.DWORD)
+
+    @contextmanager
+    def terminal_session():
+        h_in = _kernel32.GetStdHandle(_STD_INPUT_HANDLE)
+        h_out = _kernel32.GetStdHandle(_STD_OUTPUT_HANDLE)
+        old_in = wintypes.DWORD()
+        old_out = wintypes.DWORD()
+        _kernel32.GetConsoleMode(h_in, ctypes.byref(old_in))
+        _kernel32.GetConsoleMode(h_out, ctypes.byref(old_out))
+
+        new_in = ((old_in.value
+                   & ~_ENABLE_LINE_INPUT
+                   & ~_ENABLE_ECHO_INPUT
+                   & ~_ENABLE_PROCESSED_INPUT)
+                  | _ENABLE_VIRTUAL_TERMINAL_INPUT)
+        new_out = old_out.value | _ENABLE_VIRTUAL_TERMINAL_PROCESSING
+
+        try:
+            _kernel32.SetConsoleMode(h_in, new_in)
+            _kernel32.SetConsoleMode(h_out, new_out)
+            _emit(ENTER_ALT_SCREEN + HIDE_CURSOR)
+            yield
+        finally:
+            _emit(SHOW_CURSOR + EXIT_ALT_SCREEN)
+            _kernel32.SetConsoleMode(h_in, old_in.value)
+            _kernel32.SetConsoleMode(h_out, old_out.value)
+
+else:
+    raise RuntimeError(f"unsupported platform: os.name={os.name!r}")


### PR DESCRIPTION
## Summary

Closes **epic-003** (cross-platform TUI for `scripts/atari-hd/atari_hd.py`).

Stories 001–009 ship as designed; story 010 (quick-start wizard) is **deferred** to a follow-up epic so the real-hardware fidelity work in epic-004 can land first.

After story 009 landed, hardware testing on the SidecarTridge multi-device surfaced a series of partition-format bugs in `atari_hd.py` that the TUI exposed end-to-end. Those fixes shipped on this branch alongside the TUI work because they share state-model and cap-enforcement code paths.

## Stories landed (epic-003 / 001 .. 009)

- **001** — TUI framework choice & scaffolding (plain ANSI escapes, stdlib only, single-state-machine architecture)
- **002** — Main screen layout + image-file management (N=New, L=Load, Q=Quit)
- **003** — Partition list view & navigation (sparse Delete-leaves-hole, vim-style + arrow keys)
- **004** — Add / edit / delete partition dialog (modal overlay, per-field input, AHDI Type toggle)
- **005** — Format selector + TOS<1.04 toggle (atomic transitions, drop-confirm for cap violators)
- **006** — Commit / write flow with confirm dialog (atomic via `tempfile.NamedTemporaryFile` + `os.replace`)
- **007** — Load existing image (lifted partition-table parsers into `atari_hd.py`; format auto-detect)
- **008** — Help screen & keybinding reference (`?` opens centered modal; `HELP_ENTRIES` is single source of truth)
- **009** — TTY detection + `--tui` / `--no-tui` flags (auto-fall-back to prompt mode when stdin/stdout aren't a terminal)

## Post-story hardware-bugfix work

After 009 the TUI made it easy to test on real hardware. These fixes shipped on the same branch because they share state-model + cap-enforcement plumbing the TUI relies on:

- **PPDRIVER multi-primary support** restored (Compendium-validated; the earlier "single-primary only" iteration was a misdiagnosis)
- **Hybrid PRIMARY-slot cap = 255 MB** (TOS bps must stay ≤ 4096 in primary slots)
- **AHDI ident strictly follows bps** (`ahdi_partition_id` no longer forces GEM at slot 0; ident-vs-bps mismatch was producing malformed AHDI 3.0 partitions)
- **AHDI permissive GEM cap 32 → 31 MB** (real bps=512 ceiling, off-by-one fix)
- **AHDI permissive BGM cap 512 → 511 MB** (TOS NSECTS unsigned-16 ceiling)
- **Per-partition `is_extended` Kind toggle** in the dialog (free choice on PPDRIVER slot ≥ 1; locked on HDDRIVER and slot 0)
- **Auto-migration on load** for legacy multi-primary hybrid layouts (oversize primaries flipped to extended with status-bar warning)
- **`detect_format` loosened** to accept generic MBR+FAT16 images (mkfs.vfat, acsi2stm, Falcon-format, …) with surfaced compatibility warnings
- **EBR chain-link byte `0x0F → 0x05`** for PPDRIVER (matches real reference image's standard DOS convention)
- **`load_image` populates `ebr_lba` and `is_extended`** on chain logicals (TUI list distinguishes `FAT16` primary vs `FAT16+` logical)
- **Hybrid BPB stripped** to match real PPDRIVER byte-for-byte: bytes 24..62 (EBPB tail) zeroed; bytes 62..510 (boot pad) zeroed (was 0xF4 fill)
- **`hd_siz` at AHDI offset 0x1C2** + **deterministic PPDRIVER disk signature at MBR offset 0x1B8**
- Various LBA/start_lba display, label-prefix (P/E), and edge-case fixes

## Validation

- 40 / 40 unit tests pass (`scripts/atari-hd/tests/`).
- Compendium-validated against the Atari ST/STE/TT/Falcon Technical Reference notebook for every on-disk format change. CLAUDE.md now requires that validation step for future hard-disk format work.
- Cross-validated against two real reference images: `1GB-RAWDUMP.img` (real PPDRIVER) and `Atari4gb.vhd` (real HDDRIVER pure-AHDI).

## Deferred to epic-004

Real-hardware byte-fidelity gaps that remain (each tracked in `epic-004-real-hardware-compat`):

- IPL boot code at sector 0 (PPDRIVER driver loader)
- AHDI `$1234` boot checksum
- Cylinder alignment at LBA 63 (likely cause of the "writes-fine-then-corrupts" symptom from hardware testing — first epic-004 story to land)

Plus **story 010** (quick-start wizard) — additive UX, deprioritised in favour of epic-004.

## Test plan

- [ ] Run `python -m unittest discover -s tests` from `scripts/atari-hd/` — expect 40/40 green.
- [ ] Build a 1+2 PPDRIVER image via `python atari_hd.py --no-tui` and confirm `load_image` round-trips it cleanly.
- [ ] Open the TUI on macOS / Linux, verify `?` help, `L` load, `A` / `E` / `D` / `T` / `F` / `W` actions all function.
- [ ] Load a foreign-tool MBR+FAT16 image (mkfs.vfat output) and verify the TUI surfaces compatibility warnings rather than rejecting outright.